### PR TITLE
Correct directory permission of testDir

### DIFF
--- a/fs_test.go
+++ b/fs_test.go
@@ -44,7 +44,7 @@ var Fss = []Fs{&MemMapFs{}, &OsFs{}}
 func TestRead0(t *testing.T) {
 	for _, fs := range Fss {
 		path := testDir + "/" + testName
-		if err := fs.MkdirAll(testDir, 777); err != nil {
+		if err := fs.MkdirAll(testDir, 0777); err != nil {
 			t.Fatal(fs.Name(), "unable to create dir", err)
 		}
 


### PR DESCRIPTION
When `fs.MkdirAll()` was called with a permission of `777` (without the 0 prefix),
it generated the testDir with a permission of `dr----x--x`, causing the following error
during a test run:

```
=== RUN TestRead0
--- FAIL: TestRead0 (0.00 seconds)
    fs_test.go:53: OsFs create failed: open /tmp/fun/test.txt: permission denied
```

Changing the decimal `777` to octal `0777` fixes the problem.
