### PR TITLE
Fix MemMapFs.Remove() to really delete the file.

### DIFF
--- a/fs_test.go
+++ b/fs_test.go
@@ -122,12 +122,20 @@ func TestRemove(t *testing.T) {
 
 		err := fs.Remove(path)
 		if err != nil {
-			t.Fatalf("%v: Remove() failed: %v", fs.Name(), err)
+			t.Errorf("%v: Remove() failed: %v", fs.Name(), err)
+			continue
 		}
 
 		_, err = fs.Stat(path)
 		if !os.IsNotExist(err) {
 			t.Errorf("%v: Remove() didn't remove file", fs.Name())
+			continue
+		}
+
+		// Deleting non-existent file should raise error
+		err = fs.Remove(path)
+		if !os.IsNotExist(err) {
+			t.Errorf("%v: Remove() didn't raise error for non-existent file", fs.Name())
 		}
 	}
 }

--- a/fs_test.go
+++ b/fs_test.go
@@ -114,6 +114,24 @@ func TestRename(t *testing.T) {
 	}
 }
 
+func TestRemove(t *testing.T) {
+	for _, fs := range Fss {
+		path := testDir + "/" + testName
+		fs.MkdirAll(testDir, 0777) // Just in case.
+		fs.Create(path)
+
+		err := fs.Remove(path)
+		if err != nil {
+			t.Fatalf("%v: Remove() failed: %v", fs.Name(), err)
+		}
+
+		_, err = fs.Stat(path)
+		if !os.IsNotExist(err) {
+			t.Errorf("%v: Remove() didn't remove file", fs.Name())
+		}
+	}
+}
+
 func TestTruncate(t *testing.T) {
 	for _, fs := range Fss {
 		f := newFile("TestTruncate", fs, t)

--- a/memmap.go
+++ b/memmap.go
@@ -176,6 +176,8 @@ func (m *MemMapFs) Remove(name string) error {
 
 	if _, ok := m.getData()[name]; ok {
 		delete(m.getData(), name)
+	} else {
+		return &os.PathError{"remove", name, os.ErrNotExist}
 	}
 	return nil
 }

--- a/memmap.go
+++ b/memmap.go
@@ -171,13 +171,11 @@ func (m *MemMapFs) OpenFile(name string, flag int, perm os.FileMode) (File, erro
 }
 
 func (m *MemMapFs) Remove(name string) error {
-	m.rlock()
-	defer m.runlock()
+	m.lock()
+	defer m.unlock()
 
-	if _, ok := m.getData()["name"]; ok {
-		m.lock()
+	if _, ok := m.getData()[name]; ok {
 		delete(m.getData(), name)
-		m.unlock()
 	}
 	return nil
 }


### PR DESCRIPTION
It was attempting to delete a file with a hardcoded path of "name" as
opposed to the path in the `name` variable.

Fixing this exposed a deadlock because the function was attempting to
acquire an exclusive lock when it already had a read lock.

This PR also makes the function return an error for a non-existent file.