### PR TITLE
Support O_CREATE, O_APPEND and O_TRUNC flags in MemMapFs.OpenFile

### DIFF
--- a/fs_test.go
+++ b/fs_test.go
@@ -99,6 +99,17 @@ func TestOpenFile(t *testing.T) {
 			t.Errorf("%v: appending, expected '%v', got: '%v'", fs.Name(), expectedContents, string(contents))
 		}
 		f.Close()
+
+		f, err = fs.OpenFile(path, os.O_RDWR|os.O_TRUNC, 0600)
+		if err != nil {
+			t.Error(fs.Name(), "OpenFile (O_TRUNC) failed:", err)
+			continue
+		}
+		contents, _ = ioutil.ReadAll(f)
+		if string(contents) != "" {
+			t.Errorf("%v: expected truncated file, got: '%v'", fs.Name(), string(contents))
+		}
+		f.Close()
 	}
 }
 

--- a/fs_test.go
+++ b/fs_test.go
@@ -69,6 +69,21 @@ func TestRead0(t *testing.T) {
 	}
 }
 
+func TestOpenFile(t *testing.T) {
+	for _, fs := range Fss {
+		path := testDir + "/" + testName
+		fs.MkdirAll(testDir, 0777) // Just in case.
+		fs.Remove(path)            // Just in case.
+
+		f, err := fs.OpenFile(path, os.O_CREATE, 0600)
+		if err != nil {
+			t.Error(fs.Name(), "OpenFile (O_CREATE) failed:", err)
+			continue
+		}
+		f.Close()
+	}
+}
+
 func TestMemFileRead(t *testing.T) {
 	f := MemFileCreate("testfile")
 	f.WriteString("abcd")

--- a/memmap.go
+++ b/memmap.go
@@ -169,7 +169,11 @@ func (m *MemMapFs) Open(name string) (File, error) {
 }
 
 func (m *MemMapFs) OpenFile(name string, flag int, perm os.FileMode) (File, error) {
-	return m.Open(name)
+	file, err := m.Open(name)
+	if os.IsNotExist(err) && (flag&os.O_CREATE > 0) {
+		file, err = m.Create(name)
+	}
+	return file, err
 }
 
 func (m *MemMapFs) Remove(name string) error {

--- a/memmap.go
+++ b/memmap.go
@@ -183,6 +183,13 @@ func (m *MemMapFs) OpenFile(name string, flag int, perm os.FileMode) (File, erro
 			return nil, err
 		}
 	}
+	if flag&os.O_TRUNC > 0 && flag&(os.O_RDWR|os.O_WRONLY) > 0 {
+		err = file.Truncate(0)
+		if err != nil {
+			file.Close()
+			return nil, err
+		}
+	}
 	return file, nil
 }
 

--- a/memmap.go
+++ b/memmap.go
@@ -173,7 +173,17 @@ func (m *MemMapFs) OpenFile(name string, flag int, perm os.FileMode) (File, erro
 	if os.IsNotExist(err) && (flag&os.O_CREATE > 0) {
 		file, err = m.Create(name)
 	}
-	return file, err
+	if err != nil {
+		return nil, err
+	}
+	if flag&os.O_APPEND > 0 {
+		_, err = file.Seek(0, os.SEEK_END)
+		if err != nil {
+			file.Close()
+			return nil, err
+		}
+	}
+	return file, nil
 }
 
 func (m *MemMapFs) Remove(name string) error {


### PR DESCRIPTION
This adds support for the `O_CREATE`, `O_APPEND` and `O_TRUNC` flags to OpenFile. This improves parity with `os.OpenFile`, and makes it easier to unit test code that uses these flags (eg logging code.)