### PR TITLE
fix Readdir() and Readdirnames()

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,8 +100,10 @@ the ability to drop in other filesystems as desired.
 Then throughout your functions and methods use the methods familiar
 already from the OS package.
 
-Methods Available:
+File System Methods Available:
 
+       Chmod(name string, mode os.FileMode) : error
+       Chtimes(name string, atime time.Time, mtime time.Time) : error
        Create(name string) : File, error
        Mkdir(name string, perm os.FileMode) : error
        MkdirAll(path string, perm os.FileMode) : error
@@ -112,6 +114,22 @@ Methods Available:
        RemoveAll(path string) : error
        Rename(oldname, newname string) : error
        Stat(name string) : os.FileInfo, error
+
+File Interfaces and Methods Available:
+
+       io.Closer
+       io.Reader
+       io.ReaderAt
+       io.Seeker
+       io.Writer
+       io.WriterAt
+
+       Stat() : os.FileInfo, error
+       Readdir(count int) : []os.FileInfo, error
+       Readdirnames(n int) : []string, error
+       WriteString(s string) : ret int, err error
+       Truncate(size int64) : error
+       Name() : string
 
 In our case we would call `AppFs.Open()` as an example because that is how we’ve defined to
 access our filesystem.

--- a/fs_test.go
+++ b/fs_test.go
@@ -362,6 +362,7 @@ func TestReaddirSimple(t *testing.T) {
 func TestReaddir(t *testing.T) {
 	for num := 0; num < 6; num++ {
 		outputs := make([]string, len(Fss))
+		infos := make([]string, len(Fss))
 		for i, fs := range Fss {
 			root, err := fs.Open(testSubDir)
 			if err != nil {
@@ -370,15 +371,16 @@ func TestReaddir(t *testing.T) {
 			for j := 0; j < 6; j++ {
 				info, err := root.Readdir(num)
 				outputs[i] += fmt.Sprintf("%v  Error: %v\n", myFileInfo(info), err)
+				infos[i] += fmt.Sprintln(len(info), err)
 			}
 		}
 
 		fail := false
-		for i, o := range outputs {
+		for i, o := range infos {
 			if i == 0 {
 				continue
 			}
-			if o != outputs[i-1] {
+			if o != infos[i-1] {
 				fail = true
 				break
 			}

--- a/memfile.go
+++ b/memfile.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"io"
 	"os"
+	"path"
 	"sync"
 	"sync/atomic"
 )
@@ -102,7 +103,7 @@ func (f *InMemoryFile) Readdirnames(n int) (names []string, err error) {
 	fi, err := f.Readdir(n)
 	names = make([]string, len(fi))
 	for i, f := range fi {
-		names[i] = f.Name()
+		_, names[i] = path.Split(f.Name())
 	}
 	return names, err
 }
@@ -202,7 +203,10 @@ type InMemoryFileInfo struct {
 }
 
 // Implements os.FileInfo
-func (s *InMemoryFileInfo) Name() string       { return s.file.Name() }
+func (s *InMemoryFileInfo) Name() string {
+	_, name := path.Split(s.file.Name())
+	return name
+}
 func (s *InMemoryFileInfo) Mode() os.FileMode  { return s.file.mode }
 func (s *InMemoryFileInfo) ModTime() time.Time { return s.file.modtime }
 func (s *InMemoryFileInfo) IsDir() bool        { return s.file.dir }


### PR DESCRIPTION
fixes #7 

I first had to fix registerWithParent(), unRegisterWithParent() and findParent() to correctly use the MemDir of the parent directory. Then I added versions of Open() and Mkdir() that don't acquire a lock, that they can be used atomically during Create() and Mkdir(). 
Finally I changed the output of the InMemoryFileInfo.Name() and Readdirnames() functions to only return the last element of the path, as does the os package.
I also added some tests.