### PR TITLE
Fix MemMapFs.Rename()

### DIFF
--- a/fs_test.go
+++ b/fs_test.go
@@ -143,6 +143,22 @@ func TestRename(t *testing.T) {
 		if err != nil {
 			t.Fatalf("rename %q, %q failed: %v", to, from, err)
 		}
+		names, err := readDirNames(testDir, fs)
+		if err != nil {
+			t.Fatalf("readDirNames error: %v", err)
+		}
+		found := false
+		for _, e := range names {
+			if e == "renamefrom" {
+				t.Error("File is still called renamefrom")
+			}
+			if e == "renameto" {
+				found = true
+			}
+		}
+		if !found {
+			t.Error("File was not renamed to renameto")
+		}
 		defer fs.Remove(to)
 		_, err = fs.Stat(to)
 		if err != nil {
@@ -512,9 +528,6 @@ func TestReaddirAll(t *testing.T) {
 }
 
 func findNames(t *testing.T, root, sub []string, fs Fs) {
-	t.Logf("Names root: %v", root)
-	t.Logf("Names sub: %v", sub)
-
 	var foundRoot bool
 	for _, e := range root {
 		_, err := fs.Open(path.Join(testDir, e))
@@ -526,6 +539,8 @@ func findNames(t *testing.T, root, sub []string, fs Fs) {
 		}
 	}
 	if !foundRoot {
+		t.Logf("Names root: %v", root)
+		t.Logf("Names sub: %v", sub)
 		t.Error("Didn't find subdirectory we")
 	}
 
@@ -544,9 +559,13 @@ func findNames(t *testing.T, root, sub []string, fs Fs) {
 	}
 
 	if !found1 {
+		t.Logf("Names root: %v", root)
+		t.Logf("Names sub: %v", sub)
 		t.Error("Didn't find testfile1")
 	}
 	if !found2 {
+		t.Logf("Names root: %v", root)
+		t.Logf("Names sub: %v", sub)
 		t.Error("Didn't find testfile2")
 	}
 }

--- a/memmap.go
+++ b/memmap.go
@@ -293,8 +293,12 @@ func (m *MemMapFs) Rename(oldname, newname string) error {
 		if _, ok := m.getData()[newname]; !ok {
 			m.runlock()
 			m.lock()
-			m.getData()[newname] = m.getData()[oldname]
+			m.unRegisterWithParent(oldname)
+			file := m.getData()[oldname].(*InMemoryFile)
 			delete(m.getData(), oldname)
+			file.name = newname
+			m.getData()[newname] = file
+			m.registerWithParent(file)
 			m.unlock()
 			m.rlock()
 		} else {


### PR DESCRIPTION
Rename did not change the name that is saved in the InMemoryFile and also didn't change the name that is saved in the parents MemDir. I added a Test to look out for such errors in the future.