### PR TITLE
Use filepath.Abs to interpret relative file paths

### DIFF
--- a/memmap.go
+++ b/memmap.go
@@ -88,6 +88,7 @@ func (MemMapFs) Name() string { return "MemMapFS" }
 
 func (m *MemMapFs) Create(name string) (File, error) {
 	m.lock()
+	name, _ = filepath.Abs(name)
 	file := MemFileCreate(name)
 	m.getData()[name] = file
 	m.registerWithParent(file)
@@ -140,15 +141,6 @@ func (m *MemMapFs) registerWithParent(f File) {
 		}
 	}
 	pmem := parent.(*InMemoryFile)
-
-	// TODO(mbertschler): memDir is only nil when it was not made with Mkdir
-	// or lockfreeMkdir. In this case the parent is also not a real directory.
-	// This currently only happens for the file ".".
-	// This is a quick hack to make the library usable with relative paths.
-	if pmem.memDir == nil {
-		pmem.dir = true
-		pmem.memDir = &MemDirMap{}
-	}
 
 	pmem.memDir.Add(f)
 }


### PR DESCRIPTION
This should fix the problem mentioned in https://github.com/spf13/afero/issues/20. It does so by using filepath.Abs to interpret the relative file path (if there is one). It then registers it as the absolute path, rather than the relative path. This passes the test case written in the issue above.