### PR TITLE
Fix closing and deleting of files in tests

### DIFF
--- a/path_test.go
+++ b/path_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 func TestWalk(t *testing.T) {
-	defer removeAllTestFiles()
+	defer removeAllTestFiles(t)
 	var testDir string
 	for i, fs := range Fss {
 		if i == 0 {


### PR DESCRIPTION
A few things are fixed by this commit:

- check error value returned from `fs.RemoveAll` in `removeAllTestFiles`.
- Defer statements are a LIFO, and were out of order in some test functions.
- The TestReaddir* funcs were failing to close some file handles.
- `findNames` was opening file handles but ignoring them.  Bad.

Closes #35 