### PR TITLE
Fix syscall.EBADFD at FreeBSD

### DIFF
--- a/const_bsds.go
+++ b/const_bsds.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build darwin openbsd
+// +build darwin openbsd freebsd
 
 package afero
 

--- a/const_win_unix.go
+++ b/const_win_unix.go
@@ -12,6 +12,7 @@
 // limitations under the License.
 // +build !darwin
 // +build !openbsd
+// +build !freebsd
 
 package afero
 


### PR DESCRIPTION
Solve this: https://github.com/spf13/afero/issues/68

      go get github.com/spf13/afero
      # github.com/spf13/afero
      gocode/src/github.com/spf13/afero/const_win_unix.go:22: undefined: syscall.EBADFD