### PR TITLE
Closes spf13/afero#79

### DIFF
--- a/basepath.go
+++ b/basepath.go
@@ -29,7 +29,6 @@ func NewBasePathFs(source Fs, path string) Fs {
 // on a file outside the base path it returns the given file name and an error,
 // else the given file with the base path prepended
 func (b *BasePathFs) RealPath(name string) (path string, err error) {
-
 	if err := validateBasePathName(name); err != nil {
 		return "", err
 	}
@@ -39,6 +38,11 @@ func (b *BasePathFs) RealPath(name string) (path string, err error) {
 	if !strings.HasPrefix(path, bpath) {
 		return name, os.ErrNotExist
 	}
+
+	if parentBasePathFs, ok := b.source.(*BasePathFs); ok {
+		return parentBasePathFs.RealPath(path)
+	}
+
 	return path, nil
 }
 

--- a/basepath.go
+++ b/basepath.go
@@ -39,8 +39,22 @@ func (b *BasePathFs) RealPath(name string) (path string, err error) {
 		return name, os.ErrNotExist
 	}
 
+	return path, nil
+}
+
+func (b *BasePathFs) fullPath(name string) (path string, err error) {
+	if err := validateBasePathName(name); err != nil {
+		return "", err
+	}
+
+	bpath := filepath.Clean(b.path)
+	path = filepath.Clean(filepath.Join(bpath, name))
+	if !strings.HasPrefix(path, bpath) {
+		return name, os.ErrNotExist
+	}
+
 	if parentBasePathFs, ok := b.source.(*BasePathFs); ok {
-		return parentBasePathFs.RealPath(path)
+		return parentBasePathFs.fullPath(path)
 	}
 
 	return path, nil
@@ -63,14 +77,14 @@ func validateBasePathName(name string) error {
 }
 
 func (b *BasePathFs) Chtimes(name string, atime, mtime time.Time) (err error) {
-	if name, err = b.RealPath(name); err != nil {
+	if name, err = b.fullPath(name); err != nil {
 		return &os.PathError{"chtimes", name, err}
 	}
 	return b.source.Chtimes(name, atime, mtime)
 }
 
 func (b *BasePathFs) Chmod(name string, mode os.FileMode) (err error) {
-	if name, err = b.RealPath(name); err != nil {
+	if name, err = b.fullPath(name); err != nil {
 		return &os.PathError{"chmod", name, err}
 	}
 	return b.source.Chmod(name, mode)
@@ -81,66 +95,66 @@ func (b *BasePathFs) Name() string {
 }
 
 func (b *BasePathFs) Stat(name string) (fi os.FileInfo, err error) {
-	if name, err = b.RealPath(name); err != nil {
+	if name, err = b.fullPath(name); err != nil {
 		return nil, &os.PathError{"stat", name, err}
 	}
 	return b.source.Stat(name)
 }
 
 func (b *BasePathFs) Rename(oldname, newname string) (err error) {
-	if oldname, err = b.RealPath(oldname); err != nil {
+	if oldname, err = b.fullPath(oldname); err != nil {
 		return &os.PathError{"rename", oldname, err}
 	}
-	if newname, err = b.RealPath(newname); err != nil {
+	if newname, err = b.fullPath(newname); err != nil {
 		return &os.PathError{"rename", newname, err}
 	}
 	return b.source.Rename(oldname, newname)
 }
 
 func (b *BasePathFs) RemoveAll(name string) (err error) {
-	if name, err = b.RealPath(name); err != nil {
+	if name, err = b.fullPath(name); err != nil {
 		return &os.PathError{"remove_all", name, err}
 	}
 	return b.source.RemoveAll(name)
 }
 
 func (b *BasePathFs) Remove(name string) (err error) {
-	if name, err = b.RealPath(name); err != nil {
+	if name, err = b.fullPath(name); err != nil {
 		return &os.PathError{"remove", name, err}
 	}
 	return b.source.Remove(name)
 }
 
 func (b *BasePathFs) OpenFile(name string, flag int, mode os.FileMode) (f File, err error) {
-	if name, err = b.RealPath(name); err != nil {
+	if name, err = b.fullPath(name); err != nil {
 		return nil, &os.PathError{"openfile", name, err}
 	}
 	return b.source.OpenFile(name, flag, mode)
 }
 
 func (b *BasePathFs) Open(name string) (f File, err error) {
-	if name, err = b.RealPath(name); err != nil {
+	if name, err = b.fullPath(name); err != nil {
 		return nil, &os.PathError{"open", name, err}
 	}
 	return b.source.Open(name)
 }
 
 func (b *BasePathFs) Mkdir(name string, mode os.FileMode) (err error) {
-	if name, err = b.RealPath(name); err != nil {
+	if name, err = b.fullPath(name); err != nil {
 		return &os.PathError{"mkdir", name, err}
 	}
 	return b.source.Mkdir(name, mode)
 }
 
 func (b *BasePathFs) MkdirAll(name string, mode os.FileMode) (err error) {
-	if name, err = b.RealPath(name); err != nil {
+	if name, err = b.fullPath(name); err != nil {
 		return &os.PathError{"mkdir", name, err}
 	}
 	return b.source.MkdirAll(name, mode)
 }
 
 func (b *BasePathFs) Create(name string) (f File, err error) {
-	if name, err = b.RealPath(name); err != nil {
+	if name, err = b.fullPath(name); err != nil {
 		return nil, &os.PathError{"create", name, err}
 	}
 	return b.source.Create(name)

--- a/basepath_test.go
+++ b/basepath_test.go
@@ -90,3 +90,40 @@ func TestRealPath(t *testing.T) {
 	}
 
 }
+
+func TestNestedBasePaths(t *testing.T) {
+	type dirSpec struct {
+		Dir1, Dir2, Dir3 string
+	}
+	dirSpecs := []dirSpec{
+		dirSpec{Dir1: "/", Dir2: "/", Dir3: "/"},
+		dirSpec{Dir1: "/", Dir2: "/path2", Dir3: "/"},
+		dirSpec{Dir1: "/path1/dir", Dir2: "/path2/dir/", Dir3: "/path3/dir"},
+	}
+
+	for _, ds := range dirSpecs {
+		memFs := NewMemMapFs()
+		level1Fs := NewBasePathFs(memFs, ds.Dir1)
+		level2Fs := NewBasePathFs(level1Fs, ds.Dir2)
+		level3Fs := NewBasePathFs(level2Fs, ds.Dir3)
+
+		type spec struct {
+			BaseFs       Fs
+			FileName     string
+			ExpectedPath string
+		}
+		specs := []spec{
+			spec{BaseFs: level3Fs, FileName: "f.txt", ExpectedPath: filepath.Join(ds.Dir1, ds.Dir2, ds.Dir3, "f.txt")},
+			spec{BaseFs: level2Fs, FileName: "f.txt", ExpectedPath: filepath.Join(ds.Dir1, ds.Dir2, "f.txt")},
+			spec{BaseFs: level1Fs, FileName: "f.txt", ExpectedPath: filepath.Join(ds.Dir1, "f.txt")},
+		}
+
+		for _, s := range specs {
+			if actualPath, err := s.BaseFs.(*BasePathFs).RealPath(s.FileName); err != nil {
+				t.Errorf("Got error %s", err.Error())
+			} else if actualPath != s.ExpectedPath {
+				t.Errorf("Expected \n%s got \n%s", s.ExpectedPath, actualPath)
+			}
+		}
+	}
+}

--- a/basepath_test.go
+++ b/basepath_test.go
@@ -119,7 +119,7 @@ func TestNestedBasePaths(t *testing.T) {
 		}
 
 		for _, s := range specs {
-			if actualPath, err := s.BaseFs.(*BasePathFs).RealPath(s.FileName); err != nil {
+			if actualPath, err := s.BaseFs.(*BasePathFs).fullPath(s.FileName); err != nil {
 				t.Errorf("Got error %s", err.Error())
 			} else if actualPath != s.ExpectedPath {
 				t.Errorf("Expected \n%s got \n%s", s.ExpectedPath, actualPath)


### PR DESCRIPTION
Added fix to support "nested" `BasePathFs`. Unit-tests are also included.