### PR TITLE
test to replicate stat error

### DIFF
--- a/copyOnWriteFs_test.go
+++ b/copyOnWriteFs_test.go
@@ -1,0 +1,23 @@
+package afero
+
+import "testing"
+
+func TestCopyOnWrite(t *testing.T) {
+	var fs Fs
+	var err error
+	base := NewOsFs()
+	roBase := NewReadOnlyFs(base)
+	ufs := NewCopyOnWriteFs(roBase, NewMemMapFs())
+	fs = ufs
+	err = fs.MkdirAll("nonexistent/directory/", 0744)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	_, err = fs.Create("nonexistent/directory/newfile")
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+}


### PR DESCRIPTION
my solution was trivial, but I left it out so the error can be replicated first.
```
dir := filepath.Dir(name)
        var isaDir bool
        if isaDir, err = IsDir(u.base, dir); os.IsNotExist(err) {
            // skip ahead
        } else if err != nil {
            return nil, err
        }
        if isaDir {
            if err = u.layer.MkdirAll(dir, 0777); err != nil {
                return nil, err
            }
            return u.layer.OpenFile(name, flag, perm)
        }  
```