### PR TITLE
Add `FullBaseFsPath` utility method

### DIFF
--- a/basepath_test.go
+++ b/basepath_test.go
@@ -109,14 +109,13 @@ func TestNestedBasePaths(t *testing.T) {
 		level3Fs := NewBasePathFs(level2Fs, ds.Dir3)
 
 		type spec struct {
-			BaseFs       Fs
-			FileName     string
-			ExpectedPath string
+			BaseFs   Fs
+			FileName string
 		}
 		specs := []spec{
-			spec{BaseFs: level3Fs, FileName: "f.txt", ExpectedPath: filepath.Join(ds.Dir1, ds.Dir2, ds.Dir3, "f.txt")},
-			spec{BaseFs: level2Fs, FileName: "f.txt", ExpectedPath: filepath.Join(ds.Dir1, ds.Dir2, "f.txt")},
-			spec{BaseFs: level1Fs, FileName: "f.txt", ExpectedPath: filepath.Join(ds.Dir1, "f.txt")},
+			spec{BaseFs: level3Fs, FileName: "f.txt"},
+			spec{BaseFs: level2Fs, FileName: "f.txt"},
+			spec{BaseFs: level1Fs, FileName: "f.txt"},
 		}
 
 		for _, s := range specs {

--- a/util.go
+++ b/util.go
@@ -320,3 +320,12 @@ func Exists(fs Fs, path string) (bool, error) {
 	}
 	return false, err
 }
+
+func FullBaseFsPath(basePathFs *BasePathFs, relativePath string) string {
+	combinedPath := filepath.Join(basePathFs.path, relativePath)
+	if parent, ok := basePathFs.source.(*BasePathFs); ok {
+		return FullBaseFsPath(parent, combinedPath)
+	}
+
+	return combinedPath
+}

--- a/util_test.go
+++ b/util_test.go
@@ -409,3 +409,42 @@ func deleteTempDir(d string) {
 		// now what?
 	}
 }
+
+func TestFullBaseFsPath(t *testing.T) {
+	type dirSpec struct {
+		Dir1, Dir2, Dir3 string
+	}
+	dirSpecs := []dirSpec{
+		dirSpec{Dir1: "/", Dir2: "/", Dir3: "/"},
+		dirSpec{Dir1: "/", Dir2: "/path2", Dir3: "/"},
+		dirSpec{Dir1: "/path1/dir", Dir2: "/path2/dir/", Dir3: "/path3/dir"},
+		dirSpec{Dir1: "C:/path1", Dir2: "path2/dir", Dir3: "/path3/dir/"},
+	}
+
+	for _, ds := range dirSpecs {
+		memFs := NewMemMapFs()
+		level1Fs := NewBasePathFs(memFs, ds.Dir1)
+		level2Fs := NewBasePathFs(level1Fs, ds.Dir2)
+		level3Fs := NewBasePathFs(level2Fs, ds.Dir3)
+
+		type spec struct {
+			BaseFs       Fs
+			FileName     string
+			ExpectedPath string
+		}
+		specs := []spec{
+			spec{BaseFs: level3Fs, FileName: "f.txt", ExpectedPath: filepath.Join(ds.Dir1, ds.Dir2, ds.Dir3, "f.txt")},
+			spec{BaseFs: level3Fs, FileName: "", ExpectedPath: filepath.Join(ds.Dir1, ds.Dir2, ds.Dir3, "")},
+			spec{BaseFs: level2Fs, FileName: "f.txt", ExpectedPath: filepath.Join(ds.Dir1, ds.Dir2, "f.txt")},
+			spec{BaseFs: level2Fs, FileName: "", ExpectedPath: filepath.Join(ds.Dir1, ds.Dir2, "")},
+			spec{BaseFs: level1Fs, FileName: "f.txt", ExpectedPath: filepath.Join(ds.Dir1, "f.txt")},
+			spec{BaseFs: level1Fs, FileName: "", ExpectedPath: filepath.Join(ds.Dir1, "")},
+		}
+
+		for _, s := range specs {
+			if actualPath := FullBaseFsPath(s.BaseFs.(*BasePathFs), s.FileName); actualPath != s.ExpectedPath {
+				t.Errorf("Expected \n%s got \n%s", s.ExpectedPath, actualPath)
+			}
+		}
+	}
+}


### PR DESCRIPTION
This method resolves the "Full" path of the `BasePathFs`. It also resolves for nested BasePaths.
Unit tests were also added