### PR TITLE
test copyOnWrite Stat()

### DIFF
--- a/copyOnWriteFs.go
+++ b/copyOnWriteFs.go
@@ -80,7 +80,7 @@ func (u *CopyOnWriteFs) Stat(name string) (os.FileInfo, error) {
 		if e, ok := err.(*os.PathError); ok {
 			err = e.Err
 		}
-		if err == syscall.ENOENT || err == syscall.ENOTDIR {
+		if err == os.ErrNotExist || err == syscall.ENOENT || err == syscall.ENOTDIR {
 			return u.base.Stat(name)
 		}
 		return nil, origErr

--- a/copyOnWriteFs_test.go
+++ b/copyOnWriteFs_test.go
@@ -1,14 +1,15 @@
 package afero
 
-import "testing"
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+)
 
 func TestCopyOnWrite(t *testing.T) {
 	var fs Fs
 	var err error
-	base := NewOsFs()
-	roBase := NewReadOnlyFs(base)
-	ufs := NewCopyOnWriteFs(roBase, NewMemMapFs())
-	fs = ufs
+	fs = newCopyWriteFs()
 	err = fs.MkdirAll("nonexistent/directory/", 0744)
 	if err != nil {
 		t.Error(err)
@@ -19,5 +20,31 @@ func TestCopyOnWrite(t *testing.T) {
 		t.Error(err)
 		return
 	}
+}
 
+func newCopyWriteFs() Fs {
+	base := NewOsFs()
+	roBase := NewReadOnlyFs(base)
+	ufs := NewCopyOnWriteFs(roBase, NewMemMapFs())
+	return ufs
+}
+
+func TestStat(t *testing.T) {
+	var fs Fs
+	fs = newCopyWriteFs()
+	// create os file
+	var err error
+	err = os.MkdirAll("existent/", 0744)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	if err = ioutil.WriteFile("existent/file", []byte{}, 0644); err != nil {
+		t.Error(err)
+		return
+	}
+	if _, err = fs.Stat("existent/file"); err != nil {
+		t.Error(err)
+		return
+	}
 }


### PR DESCRIPTION
So this next issue with copyOnWrite was that the when opening a file that existed in the os but not in memory, the Stat function error was returning a os.NotExist error but wasn't getting caught appropriately.
It may warrant further exploration why the memory layer was returning an os.NotExistErr

the test will fail if the `if err == syscall.ENOENT || err == syscall.ENOTDIR {` is left in
