### PR TITLE
S3 FS implementation

### DIFF
--- a/afero_test.go
+++ b/afero_test.go
@@ -224,7 +224,7 @@ func TestRename(t *testing.T) {
 		if err != nil {
 			t.Errorf("%s: rename %q, %q failed: %v", fs.Name(), exists, from, err)
 		}
-		names, err := readDirNames(fs, tDir)
+		names, err := ReadDirNames(fs, tDir)
 		if err != nil {
 			t.Errorf("%s: readDirNames error: %v", fs.Name(), err)
 		}

--- a/path.go
+++ b/path.go
@@ -24,7 +24,7 @@ import (
 // readDirNames reads the directory named by dirname and returns
 // a sorted list of directory entries.
 // adapted from https://golang.org/src/path/filepath/path.go
-func readDirNames(fs Fs, dirname string) ([]string, error) {
+func ReadDirNames(fs Fs, dirname string) ([]string, error) {
 	f, err := fs.Open(dirname)
 	if err != nil {
 		return nil, err
@@ -53,7 +53,7 @@ func walk(fs Fs, path string, info os.FileInfo, walkFn filepath.WalkFunc) error 
 		return nil
 	}
 
-	names, err := readDirNames(fs, path)
+	names, err := ReadDirNames(fs, path)
 	if err != nil {
 		return walkFn(path, info, err)
 	}

--- a/s3/s3_file.go
+++ b/s3/s3_file.go
@@ -1,0 +1,266 @@
+package s3
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/s3/s3iface"
+	"github.com/spf13/afero"
+)
+
+// S3File represents a file in S3.
+// It is not threadsafe.
+type S3File struct {
+	bucket string
+	name   string
+	s3Fs   afero.Fs
+	s3API  s3iface.S3API
+
+	// state
+	offset int
+	closed bool
+
+	// readdir state
+	readdirContinuationToken *string
+	readdirNotTruncated      bool
+}
+
+var _ afero.File = (*S3File)(nil)
+
+// NewS3File initializes an S3File object.
+func NewS3File(bucket, name string, s3API s3iface.S3API, s3Fs afero.Fs) *S3File {
+	return &S3File{
+		bucket: bucket,
+		name:   name,
+		s3API:  s3API,
+		s3Fs:   s3Fs,
+		offset: 0,
+		closed: false,
+	}
+}
+
+// Name returns the filename, i.e. S3 path without the bucket name.
+func (f *S3File) Name() string { return f.name }
+
+// Readdir reads the contents of the directory associated with file and
+// returns a slice of up to n FileInfo values, as would be returned
+// by ListObjects, in directory order. Subsequent calls on the same file will yield further FileInfos.
+//
+// If n > 0, Readdir returns at most n FileInfo structures. In this case, if
+// Readdir returns an empty slice, it will return a non-nil error
+// explaining why. At the end of a directory, the error is io.EOF.
+//
+// If n <= 0, Readdir returns all the FileInfo from the directory in
+// a single slice. In this case, if Readdir succeeds (reads all
+// the way to the end of the directory), it returns the slice and a
+// nil error. If it encounters an error before the end of the
+// directory, Readdir returns the FileInfo read until that point
+// and a non-nil error.
+func (f *S3File) Readdir(n int) ([]os.FileInfo, error) {
+	if f.readdirNotTruncated {
+		return nil, io.EOF
+	}
+	if n <= 0 {
+		return f.ReaddirAll()
+	}
+	// ListObjects treats leading slashes as part of the directory name
+	// It also needs a trailing slash to list contents of a directory.
+	name := trimLeadingSlash(f.Name()) + "/"
+	output, err := f.s3API.ListObjectsV2(&s3.ListObjectsV2Input{
+		ContinuationToken: f.readdirContinuationToken,
+		Bucket:            aws.String(f.bucket),
+		Prefix:            aws.String(name),
+		Delimiter:         aws.String("/"),
+		MaxKeys:           aws.Int64(int64(n)),
+	})
+	if err != nil {
+		return nil, err
+	}
+	f.readdirContinuationToken = output.NextContinuationToken
+	if !(*output.IsTruncated) {
+		f.readdirNotTruncated = true
+	}
+	fis := []os.FileInfo{}
+	for _, subfolder := range output.CommonPrefixes {
+		fis = append(fis, NewS3FileInfo(filepath.Base("/"+*subfolder.Prefix), true, 0, time.Time{}))
+	}
+	for _, fileObject := range output.Contents {
+		if hasTrailingSlash(*fileObject.Key) {
+			// S3 includes <name>/ in the Contents listing for <name>
+			continue
+		}
+
+		fis = append(fis, NewS3FileInfo(filepath.Base("/"+*fileObject.Key), false, *fileObject.Size, *fileObject.LastModified))
+	}
+
+	return fis, nil
+}
+
+func (f *S3File) ReaddirAll() ([]os.FileInfo, error) {
+	fileInfos := []os.FileInfo{}
+	for {
+		infos, err := f.Readdir(100)
+		fileInfos = append(fileInfos, infos...)
+		if err != nil {
+			if err == io.EOF {
+				break
+			} else {
+				return nil, err
+			}
+		}
+	}
+	return fileInfos, nil
+}
+
+// Readdirnames reads and returns a slice of names from the directory f.
+//
+// If n > 0, Readdirnames returns at most n names. In this case, if
+// Readdirnames returns an empty slice, it will return a non-nil error
+// explaining why. At the end of a directory, the error is io.EOF.
+//
+// If n <= 0, Readdirnames returns all the names from the directory in
+// a single slice. In this case, if Readdirnames succeeds (reads all
+// the way to the end of the directory), it returns the slice and a
+// nil error. If it encounters an error before the end of the
+// directory, Readdirnames returns the names read until that point and
+// a non-nil error.
+func (f *S3File) Readdirnames(n int) ([]string, error) {
+	fi, err := f.Readdir(n)
+	names := make([]string, len(fi))
+	for i, f := range fi {
+		_, names[i] = filepath.Split(f.Name())
+	}
+	return names, err
+}
+
+// Stat returns the FileInfo structure describing file.
+// If there is an error, it will be of type *PathError.
+func (f *S3File) Stat() (os.FileInfo, error) {
+	return f.s3Fs.Stat(f.Name())
+}
+
+// Sync is a noop.
+func (f *S3File) Sync() error {
+	return nil
+}
+
+// Truncate changes the size of the file.
+// It does not change the I/O offset.
+// If there is an error, it will be of type *PathError.
+func (f *S3File) Truncate(size int64) error {
+	panic("implement Truncate")
+	return nil
+}
+
+// WriteString is like Write, but writes the contents of string s rather than
+// a slice of bytes.
+func (f *S3File) WriteString(s string) (int, error) {
+	return f.Write([]byte(s))
+}
+
+// Close closes the File, rendering it unusable for I/O.
+// It returns an error, if any.
+func (f *S3File) Close() error {
+	f.closed = true
+	return nil
+}
+
+// Read reads up to len(b) bytes from the File.
+// It returns the number of bytes read and an error, if any.
+// EOF is signaled by a zero count with err set to io.EOF.
+func (f *S3File) Read(p []byte) (int, error) {
+	if f.closed {
+		// mimic os.File's read after close behavior
+		panic("read after close")
+	}
+	if f.offset != 0 {
+		panic("TODO: non-offset == 0 read")
+	}
+	if len(p) == 0 {
+		return 0, nil
+	}
+	output, err := f.s3API.GetObject(&s3.GetObjectInput{
+		Bucket: aws.String(f.bucket),
+		Key:    aws.String(f.name),
+	})
+	if err != nil {
+		return 0, err
+	}
+	defer output.Body.Close()
+	n, err := output.Body.Read(p)
+	f.offset += n
+	return n, err
+}
+
+// ReadAt reads len(p) bytes from the file starting at byte offset off.
+// It returns the number of bytes read and the error, if any.
+// ReadAt always returns a non-nil error when n < len(b).
+// At end of file, that error is io.EOF.
+func (f *S3File) ReadAt(p []byte, off int64) (n int, err error) {
+	_, err = f.Seek(off, 0)
+	if err != nil {
+		return
+	}
+	n, err = f.Read(p)
+	return
+}
+
+// Seek sets the offset for the next Read or Write on file to offset, interpreted
+// according to whence: 0 means relative to the origin of the file, 1 means
+// relative to the current offset, and 2 means relative to the end.
+// It returns the new offset and an error, if any.
+// The behavior of Seek on a file opened with O_APPEND is not specified.
+func (f *S3File) Seek(offset int64, whence int) (int64, error) {
+	switch whence {
+	case 0:
+		f.offset = int(offset)
+	case 1:
+		f.offset += int(offset)
+	case 2:
+		// can probably do this if we had GetObjectOutput (ContentLength)
+		panic("TODO: whence == 2 seek")
+	}
+	return int64(f.offset), nil
+}
+
+// Write writes len(b) bytes to the File.
+// It returns the number of bytes written and an error, if any.
+// Write returns a non-nil error when n != len(b).
+func (f *S3File) Write(p []byte) (int, error) {
+	if f.closed {
+		// mimic os.File's write after close behavior
+		panic("write after close")
+	}
+	if f.offset != 0 {
+		panic("TODO: non-offset == 0 write")
+	}
+	readSeeker := bytes.NewReader(p)
+	size := int(readSeeker.Size())
+	if _, err := f.s3API.PutObject(&s3.PutObjectInput{
+		Bucket:               aws.String(f.bucket),
+		Key:                  aws.String(f.name),
+		Body:                 readSeeker,
+		ServerSideEncryption: aws.String("AES256"),
+	}); err != nil {
+		return 0, err
+	}
+	f.offset += size
+	return size, nil
+}
+
+// WriteAt writes len(p) bytes to the file starting at byte offset off.
+// It returns the number of bytes written and an error, if any.
+// WriteAt returns a non-nil error when n != len(p).
+func (f *S3File) WriteAt(p []byte, off int64) (n int, err error) {
+	_, err = f.Seek(off, 0)
+	if err != nil {
+		return
+	}
+	n, err = f.Write(p)
+	return
+}

--- a/s3/s3_fileinfo.go
+++ b/s3/s3_fileinfo.go
@@ -1,0 +1,60 @@
+package s3
+
+import (
+	"os"
+	"time"
+)
+
+// S3FileInfo implements os.FileInfo for a file in S3.
+type S3FileInfo struct {
+	name        string
+	directory   bool
+	sizeInBytes int64
+	modTime     time.Time
+}
+
+func NewS3FileInfo(name string, directory bool, sizeInBytes int64, modTime time.Time) S3FileInfo {
+	return S3FileInfo{
+		name:        name,
+		directory:   directory,
+		sizeInBytes: sizeInBytes,
+	}
+}
+
+var _ os.FileInfo = (*S3FileInfo)(nil)
+
+// Name provides the base name of the file.
+func (fi S3FileInfo) Name() string {
+	return fi.name
+}
+
+// Size provides the length in bytes for a file.
+func (fi S3FileInfo) Size() int64 {
+	return fi.sizeInBytes
+}
+
+// Mode provides the file mode bits. For a file in S3 this defaults to
+// 664 for files, 775 for directories.
+// In the future this may return differently depending on the permissions
+// available on the bucket.
+func (fi S3FileInfo) Mode() os.FileMode {
+	if fi.directory {
+		return 0755
+	}
+	return 0664
+}
+
+// ModTime provides the last modification time.
+func (fi S3FileInfo) ModTime() time.Time {
+	return fi.modTime
+}
+
+// IsDir provides the abbreviation for Mode().IsDir()
+func (fi S3FileInfo) IsDir() bool {
+	return fi.directory
+}
+
+// Sys provides the underlying data source (can return nil)
+func (fi S3FileInfo) Sys() interface{} {
+	return nil
+}

--- a/s3/s3_fs.go
+++ b/s3/s3_fs.go
@@ -1,0 +1,235 @@
+package s3
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/s3/s3iface"
+	"github.com/spf13/afero"
+)
+
+// S3Fs is an FS object backed by S3.
+type S3Fs struct {
+	bucket string
+	s3API  s3iface.S3API
+}
+
+var _ afero.Fs = (*S3Fs)(nil)
+
+// NewS3Fs creates a new S3Fs object writing files to a given S3 bucket.
+func NewS3Fs(bucket string, s3API s3iface.S3API) *S3Fs {
+	return &S3Fs{bucket: bucket, s3API: s3API}
+}
+
+// Name returns the type of FS object this is: S3Fs.
+func (S3Fs) Name() string { return "S3Fs" }
+
+// Create a file.
+func (fs S3Fs) Create(name string) (afero.File, error) {
+	file, err := fs.Open(name)
+	if err != nil {
+		return file, err
+	}
+	// Create(), like all of S3, is eventually consistent.
+	// To protect against unexpected behavior, have this method
+	// wait until S3 reports the object exists.
+	if s3Client, ok := fs.s3API.(*s3.S3); ok {
+		return file, s3Client.WaitUntilObjectExists(&s3.HeadObjectInput{
+			Bucket: aws.String(fs.bucket),
+			Key:    aws.String(name),
+		})
+	}
+	return file, err
+}
+
+// Mkdir makes a directory in S3.
+func (fs S3Fs) Mkdir(name string, perm os.FileMode) error {
+	_, err := fs.OpenFile(fmt.Sprintf("%s/", filepath.Clean(name)), os.O_CREATE, perm)
+	return err
+}
+
+// MkdirAll creates a directory and all parent directories if necessary.
+func (fs S3Fs) MkdirAll(path string, perm os.FileMode) error {
+	return fs.Mkdir(path, perm)
+}
+
+// Open a file for reading.
+// If the file doesn't exist, Open will create the file.
+func (fs S3Fs) Open(name string) (afero.File, error) {
+	if _, err := fs.Stat(name); err != nil {
+		if os.IsNotExist(err) {
+			return fs.OpenFile(name, os.O_CREATE, 0777)
+		}
+		return (*S3File)(nil), err
+	}
+	return NewS3File(fs.bucket, name, fs.s3API, fs), nil
+}
+
+// OpenFile opens a file.
+func (fs S3Fs) OpenFile(name string, flag int, perm os.FileMode) (afero.File, error) {
+	file := NewS3File(fs.bucket, name, fs.s3API, fs)
+	if flag&os.O_APPEND != 0 {
+		return file, errors.New("S3 is eventually consistent. Appending files will lead to trouble.")
+	}
+	if flag&os.O_CREATE != 0 {
+		if _, err := file.WriteString(""); err != nil {
+			return file, err
+		}
+	}
+	return file, nil
+}
+
+// Remove a file.
+func (fs S3Fs) Remove(name string) error {
+	if _, err := fs.Stat(name); err != nil {
+		return err
+	}
+	_, err := fs.s3API.DeleteObject(&s3.DeleteObjectInput{
+		Bucket: aws.String(fs.bucket),
+		Key:    aws.String(name),
+	})
+	return err
+}
+
+// ForceRemove doesn't error if a file does not exist.
+func (fs S3Fs) ForceRemove(name string) error {
+	_, err := fs.s3API.DeleteObject(&s3.DeleteObjectInput{
+		Bucket: aws.String(fs.bucket),
+		Key:    aws.String(name),
+	})
+	return err
+}
+
+// RemoveAll removes a path.
+func (fs S3Fs) RemoveAll(path string) error {
+	s3dir := NewS3File(fs.bucket, path, fs.s3API, fs)
+	fis, err := s3dir.Readdir(0)
+	if err != nil {
+		return err
+	}
+	for _, fi := range fis {
+		fullpath := filepath.Join(s3dir.Name(), fi.Name())
+		if fi.IsDir() {
+			if err := fs.RemoveAll(fullpath); err != nil {
+				return err
+			}
+		} else {
+			if err := fs.ForceRemove(fullpath); err != nil {
+				return err
+			}
+		}
+	}
+	// finally remove the "file" representing the directory
+	if err := fs.ForceRemove(s3dir.Name() + "/"); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Rename a file.
+// There is no method to directly rename an S3 object, so the Rename
+// will copy the file to an object with the new name and then delete
+// the original.
+func (fs S3Fs) Rename(oldname, newname string) error {
+	if oldname == newname {
+		return nil
+	}
+	_, err := fs.s3API.CopyObject(&s3.CopyObjectInput{
+		Bucket:               aws.String(fs.bucket),
+		CopySource:           aws.String(fs.bucket + oldname),
+		Key:                  aws.String(newname),
+		ServerSideEncryption: aws.String("AES256"),
+	})
+	if err != nil {
+		return err
+	}
+	_, err = fs.s3API.DeleteObject(&s3.DeleteObjectInput{
+		Bucket: aws.String(fs.bucket),
+		Key:    aws.String(oldname),
+	})
+	return err
+}
+
+func hasTrailingSlash(s string) bool {
+	return len(s) > 0 && s[len(s)-1] == '/'
+}
+
+func trimLeadingSlash(s string) string {
+	if len(s) > 0 && s[0] == '/' {
+		return s[1:]
+	}
+	return s
+}
+
+// Stat returns a FileInfo describing the named file.
+// If there is an error, it will be of type *os.PathError.
+func (fs S3Fs) Stat(name string) (os.FileInfo, error) {
+	nameClean := filepath.Clean(name)
+	out, err := fs.s3API.HeadObject(&s3.HeadObjectInput{
+		Bucket: aws.String(fs.bucket),
+		Key:    aws.String(nameClean),
+	})
+	if err != nil {
+		if strings.Contains(err.Error(), "404") {
+			statDir, err := fs.statDirectory(name)
+			return statDir, err
+		}
+		return S3FileInfo{}, &os.PathError{
+			Op:   "stat",
+			Path: name,
+			Err:  err,
+		}
+	} else if err == nil && hasTrailingSlash(name) {
+		// user asked for a directory, but this is a file
+		return S3FileInfo{}, &os.PathError{
+			Op:   "stat",
+			Path: name,
+			//Err:  errors.New("not a directory"),
+			Err: os.ErrNotExist,
+		}
+	}
+	return NewS3FileInfo(filepath.Base(name), false, *out.ContentLength, *out.LastModified), nil
+}
+
+func (fs S3Fs) statDirectory(name string) (os.FileInfo, error) {
+	nameClean := filepath.Clean(name)
+	out, err := fs.s3API.ListObjectsV2(&s3.ListObjectsV2Input{
+		Bucket:  aws.String(fs.bucket),
+		Prefix:  aws.String(trimLeadingSlash(nameClean)),
+		MaxKeys: aws.Int64(1),
+	})
+	if err != nil {
+		return S3FileInfo{}, &os.PathError{
+			Op:   "stat",
+			Path: name,
+			Err:  err,
+		}
+	}
+	if *out.KeyCount == 0 && name != "" {
+		return S3FileInfo{}, &os.PathError{
+			Op:   "stat",
+			Path: name,
+			//Err:  errors.New("no such file or directory"),
+			Err: os.ErrNotExist,
+		}
+	}
+	return NewS3FileInfo(filepath.Base(name), true, 0, time.Time{}), nil
+}
+
+// Chmod is TODO
+func (S3Fs) Chmod(name string, mode os.FileMode) error {
+	panic("implement Chmod")
+	return nil
+}
+
+// Chtimes is TODO
+func (S3Fs) Chtimes(name string, atime time.Time, mtime time.Time) error {
+	panic("implement Chtimes")
+	return nil
+}

--- a/s3/s3_test.go
+++ b/s3/s3_test.go
@@ -1,0 +1,95 @@
+package s3
+
+import (
+	"flag"
+	"log"
+	"os"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/spf13/afero/test"
+)
+
+var s3bucket string
+
+func init() {
+	flag.StringVar(&s3bucket, "s3bucket", "", "s3 bucket to use for testing")
+	flag.Parse()
+
+	if s3bucket == "" {
+		log.Fatal("must provide -s3bucket for testing this package")
+	}
+	for _, requiredEnv := range []string{"AWS_REGION", "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"} {
+		if os.Getenv(requiredEnv) == "" {
+			log.Fatalf("must set %s for testing this package", requiredEnv)
+		}
+	}
+}
+
+func TestRead0(t *testing.T) {
+	t.Skip("TODO: S3 FS doesn't support nonzero offset read/writes")
+	test.Read0(t, NewS3Fs(s3bucket, s3.New(session.New())))
+}
+
+func TestOpenFile(t *testing.T) {
+	t.Skip("S3 doesn't support appending, which this test performs")
+	test.OpenFile(t, NewS3Fs(s3bucket, s3.New(session.New())))
+}
+
+func TestCreate(t *testing.T) {
+	test.Create(t, NewS3Fs(s3bucket, s3.New(session.New())))
+}
+
+func TestRename(t *testing.T) {
+	test.Rename(t, NewS3Fs(s3bucket, s3.New(session.New())))
+}
+
+func TestRemove(t *testing.T) {
+	test.Remove(t, NewS3Fs(s3bucket, s3.New(session.New())))
+}
+
+func TestTruncate(t *testing.T) {
+	t.Skip("TODO: implement Truncate")
+	test.Truncate(t, NewS3Fs(s3bucket, s3.New(session.New())))
+}
+
+func TestReadWriteSeek(t *testing.T) {
+	t.Skip("TODO: S3 FS doesn't support nonzero offset read/writes")
+	test.ReadWriteSeek(t, NewS3Fs(s3bucket, s3.New(session.New())))
+}
+
+func TestSeek(t *testing.T) {
+	t.Skip("TODO: S3 FS doesn't support whence==2 seeks")
+	test.Seek(t, NewS3Fs(s3bucket, s3.New(session.New())))
+}
+
+func TestReadAt(t *testing.T) {
+	t.Skip("TODO: S3 FS doesn't support nonzero offset read/writes")
+	test.ReadAt(t, NewS3Fs(s3bucket, s3.New(session.New())))
+}
+
+func TestWriteAt(t *testing.T) {
+	t.Skip("TODO: S3 FS doesn't support nonzero offset read/writes")
+	test.WriteAt(t, NewS3Fs(s3bucket, s3.New(session.New())))
+}
+
+func TestReaddirnames(t *testing.T) {
+	test.Readdirnames(t, NewS3Fs(s3bucket, s3.New(session.New())))
+}
+
+func TestReaddirSimple(t *testing.T) {
+	test.ReaddirSimple(t, NewS3Fs(s3bucket, s3.New(session.New())))
+}
+
+func TestReaddirAll(t *testing.T) {
+	test.ReaddirAll(t, NewS3Fs(s3bucket, s3.New(session.New())))
+}
+
+func TestStatDirectory(t *testing.T) {
+	test.StatDirectory(t, NewS3Fs(s3bucket, s3.New(session.New())))
+}
+
+func TestStatFile(t *testing.T) {
+	test.StatFile(t, NewS3Fs(s3bucket, s3.New(session.New())))
+}

--- a/test/tests.go
+++ b/test/tests.go
@@ -1,0 +1,764 @@
+// package test provides generic tests of Fs objects
+package test
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"strings"
+	"syscall"
+	"testing"
+
+	"github.com/spf13/afero"
+)
+
+var testName = "test.txt"
+
+func mustTempDir(fs afero.Fs) string {
+	name, err := afero.TempDir(fs, "", "afero")
+	if err != nil {
+		panic(fmt.Sprint("unable to work with test dir", err))
+	}
+	return name
+}
+
+func mustTempFile(fs afero.Fs) afero.File {
+	x, err := afero.TempFile(fs, "", "afero")
+	if err != nil {
+		panic(fmt.Sprint("unable to work with temp file", err))
+	}
+	return x
+}
+
+func Read0(t *testing.T, fs afero.Fs) {
+	f := mustTempFile(fs)
+	defer f.Close()
+	defer fs.Remove(f.Name())
+	f.WriteString("Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.")
+
+	var b []byte
+	// b := make([]byte, 0)
+	n, err := f.Read(b)
+	if n != 0 || err != nil {
+		t.Errorf("%v: Read(0) = %d, %v, want 0, nil", fs.Name(), n, err)
+	}
+	f.Seek(0, 0)
+	b = make([]byte, 100)
+	n, err = f.Read(b)
+	if n <= 0 || err != nil {
+		t.Errorf("%v: Read(100) = %d, %v, want >0, nil", fs.Name(), n, err)
+	}
+}
+
+func OpenFile(t *testing.T, fs afero.Fs) {
+	tmp := mustTempDir(fs)
+	defer fs.RemoveAll(tmp)
+
+	path := filepath.Join(tmp, testName)
+	f, err := fs.OpenFile(path, os.O_RDWR|os.O_CREATE, 0600)
+	if err != nil {
+		t.Fatal(fs.Name(), "OpenFile (O_CREATE) failed:", err)
+	}
+	io.WriteString(f, "initial")
+	f.Close()
+
+	f, err = fs.OpenFile(path, os.O_WRONLY|os.O_APPEND, 0600)
+	if err != nil {
+		t.Fatal(fs.Name(), "OpenFile (O_APPEND) failed:", err)
+	}
+	io.WriteString(f, "|append")
+	f.Close()
+
+	f, err = fs.OpenFile(path, os.O_RDONLY, 0600)
+	contents, _ := ioutil.ReadAll(f)
+	expectedContents := "initial|append"
+	if string(contents) != expectedContents {
+		t.Errorf("%v: appending, expected '%v', got: '%v'", fs.Name(), expectedContents, string(contents))
+	}
+	f.Close()
+
+	f, err = fs.OpenFile(path, os.O_RDWR|os.O_TRUNC, 0600)
+	if err != nil {
+		t.Fatal(fs.Name(), "OpenFile (O_TRUNC) failed:", err)
+	}
+	contents, _ = ioutil.ReadAll(f)
+	if string(contents) != "" {
+		t.Errorf("%v: expected truncated file, got: '%v'", fs.Name(), string(contents))
+	}
+	f.Close()
+}
+
+func Create(t *testing.T, fs afero.Fs) {
+	tmp := mustTempDir(fs)
+	defer fs.RemoveAll(tmp)
+
+	path := filepath.Join(tmp, testName)
+	f, err := fs.Create(path)
+	if err != nil {
+		f.Close()
+		t.Fatal(fs.Name(), "Create failed:", err)
+	}
+	io.WriteString(f, "initial")
+	f.Close()
+
+	f, err = fs.Create(path)
+	if err != nil {
+		f.Close()
+		t.Fatal(fs.Name(), "Create failed:", err)
+	}
+	secondContent := "second create"
+	io.WriteString(f, secondContent)
+	f.Close()
+
+	f, err = fs.Open(path)
+	if err != nil {
+		f.Close()
+		t.Fatal(fs.Name(), "Open failed:", err)
+	}
+	buf, err := afero.ReadAll(f)
+	if err != nil {
+		f.Close()
+		t.Fatal(fs.Name(), "ReadAll failed:", err)
+	}
+	if string(buf) != secondContent {
+		f.Close()
+		t.Fatal(fs.Name(), "Content should be", "\""+secondContent+"\" but is \""+string(buf)+"\"")
+	}
+	f.Close()
+}
+
+func Rename(t *testing.T, fs afero.Fs) {
+	tDir := mustTempDir(fs)
+	defer fs.RemoveAll(tDir)
+
+	from := filepath.Join(tDir, "/renamefrom")
+	to := filepath.Join(tDir, "/renameto")
+	exists := filepath.Join(tDir, "/renameexists")
+	file, err := fs.Create(from)
+	if err != nil {
+		t.Fatalf("%s: open %q failed: %v", fs.Name(), to, err)
+	}
+	if err = file.Close(); err != nil {
+		t.Errorf("%s: close %q failed: %v", fs.Name(), to, err)
+	}
+	file, err = fs.Create(exists)
+	if err != nil {
+		t.Fatalf("%s: open %q failed: %v", fs.Name(), to, err)
+	}
+	if err = file.Close(); err != nil {
+		t.Errorf("%s: close %q failed: %v", fs.Name(), to, err)
+	}
+	err = fs.Rename(from, to)
+	if err != nil {
+		t.Fatalf("%s: rename %q, %q failed: %v", fs.Name(), to, from, err)
+	}
+	file, err = fs.Create(from)
+	if err != nil {
+		t.Fatalf("%s: open %q failed: %v", fs.Name(), to, err)
+	}
+	if err = file.Close(); err != nil {
+		t.Errorf("%s: close %q failed: %v", fs.Name(), to, err)
+	}
+	err = fs.Rename(from, exists)
+	if err != nil {
+		t.Errorf("%s: rename %q, %q failed: %v", fs.Name(), exists, from, err)
+	}
+	names, err := afero.ReadDirNames(fs, tDir)
+	if err != nil {
+		t.Errorf("%s: readDirNames error: %v", fs.Name(), err)
+	}
+	found := false
+	for _, e := range names {
+		if e == "renamefrom" {
+			t.Error("File is still called renamefrom")
+		}
+		if e == "renameto" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("File was not renamed to renameto")
+	}
+
+	_, err = fs.Stat(to)
+	if err != nil {
+		t.Errorf("%s: stat %q failed: %v", fs.Name(), to, err)
+	}
+}
+
+func Remove(t *testing.T, fs afero.Fs) {
+	x, err := afero.TempFile(fs, "", "afero")
+	if err != nil {
+		t.Error(fmt.Sprint("unable to work with temp file", err))
+	}
+
+	path := x.Name()
+	x.Close()
+
+	tDir := filepath.Dir(path)
+
+	err = fs.Remove(path)
+	if err != nil {
+		t.Fatalf("%v: Remove() failed: %v", fs.Name(), err)
+	}
+
+	_, err = fs.Stat(path)
+	if !os.IsNotExist(err) {
+		t.Fatalf("%v: Remove() didn't remove file", fs.Name())
+	}
+
+	// Deleting non-existent file should raise error
+	err = fs.Remove(path)
+	if !os.IsNotExist(err) {
+		t.Errorf("%v: Remove() didn't raise error for non-existent file", fs.Name())
+	}
+
+	f, err := fs.Open(tDir)
+	if err != nil {
+		t.Error("TestDir should still exist:", err)
+	}
+
+	names, err := f.Readdirnames(-1)
+	if err != nil {
+		t.Error("Readdirnames failed:", err)
+	}
+
+	for _, e := range names {
+		if e == testName {
+			t.Error("File was not removed from parent directory")
+		}
+	}
+}
+
+func Truncate(t *testing.T, fs afero.Fs) {
+	f := mustTempFile(fs)
+	defer f.Close()
+	defer fs.Remove(f.Name())
+
+	checkSize(t, f, 0)
+	f.Write([]byte("hello, world\n"))
+	checkSize(t, f, 13)
+	f.Truncate(10)
+	checkSize(t, f, 10)
+	f.Truncate(1024)
+	checkSize(t, f, 1024)
+	f.Truncate(0)
+	checkSize(t, f, 0)
+	_, err := f.Write([]byte("surprise!"))
+	if err == nil {
+		checkSize(t, f, 13+9) // wrote at offset past where hello, world was.
+	}
+}
+
+func ReadWriteSeek(t *testing.T, fs afero.Fs) {
+	f := mustTempFile(fs)
+	defer f.Close()
+	defer fs.Remove(f.Name())
+
+	const data = "hello, world\n"
+	io.WriteString(f, data)
+
+	type readInput struct {
+		p []byte
+	}
+	type readOutput struct {
+		p   []byte
+		n   int
+		err error
+	}
+	type readTest struct {
+		input    readInput
+		expected readOutput
+	}
+	type writeInput struct {
+		p []byte
+	}
+	type writeOutput struct {
+		n   int
+		err error
+	}
+	type writeTest struct {
+		input    writeInput
+		expected writeOutput
+	}
+	type seekInput struct {
+		offset int64
+		whence int
+	}
+	type seekOutput struct {
+		offset int64
+		err    error
+	}
+	type seekTest struct {
+		input    seekInput
+		expected seekOutput
+	}
+	var tests = []interface{}{
+		readTest{
+			input:    readInput{make([]byte, 2)},
+			expected: readOutput{make([]byte, 2), 0, io.EOF},
+		},
+		seekTest{
+			input:    seekInput{-1, 1},
+			expected: seekOutput{int64(len(data) - 1), nil},
+		},
+		readTest{
+			input:    readInput{make([]byte, 2)},
+			expected: readOutput{[]byte{'\n', uint8(0)}, 1, nil},
+		},
+		seekTest{
+			input:    seekInput{0, 0},
+			expected: seekOutput{0, nil},
+		},
+		readTest{
+			input:    readInput{make([]byte, len(data))},
+			expected: readOutput{[]byte(data), len(data), nil},
+		},
+		seekTest{
+			input:    seekInput{0, 0},
+			expected: seekOutput{0, nil},
+		},
+		writeTest{
+			input:    writeInput{[]byte("c")},
+			expected: writeOutput{1, nil},
+		},
+		readTest{
+			input:    readInput{make([]byte, len(data)-1)},
+			expected: readOutput{[]byte(data[1:]), len(data[1:]), nil},
+		},
+		seekTest{
+			input:    seekInput{-1, 1},
+			expected: seekOutput{int64(len(data) - 1), nil},
+		},
+		writeTest{
+			input:    writeInput{[]byte("!\n")},
+			expected: writeOutput{2, nil},
+		},
+		seekTest{
+			input:    seekInput{0, 0},
+			expected: seekOutput{0, nil},
+		},
+		readTest{
+			input:    readInput{make([]byte, len(data)+1)},
+			expected: readOutput{[]byte("cello, world!\n"), len("cello, world!\n"), nil},
+		},
+	}
+	for idx, testi := range tests {
+		switch test := testi.(type) {
+		case readTest:
+			n, err := f.Read(test.input.p)
+			got := readOutput{
+				p:   test.input.p,
+				n:   n,
+				err: err,
+			}
+			if !reflect.DeepEqual(got, test.expected) {
+				t.Fatalf("read %d\nexpected %#v\ngot      %#v", idx, test.expected, got)
+			}
+		case writeTest:
+			n, err := f.Write(test.input.p)
+			got := writeOutput{
+				n:   n,
+				err: err,
+			}
+			if !reflect.DeepEqual(got, test.expected) {
+				t.Fatalf("write %d\nexpected %#v\ngot     %#v", idx, test.expected, got)
+			}
+		case seekTest:
+			offset, err := f.Seek(test.input.offset, test.input.whence)
+			got := seekOutput{
+				offset: offset,
+				err:    err,
+			}
+			if !reflect.DeepEqual(got, test.expected) {
+				t.Fatalf("seek %d\nexpected %#v\ngot     %#v", idx, test.expected, got)
+			}
+		}
+	}
+}
+
+func Seek(t *testing.T, fs afero.Fs) {
+	f := mustTempFile(fs)
+	defer f.Close()
+	defer fs.Remove(f.Name())
+
+	const data = "hello, world\n"
+	io.WriteString(f, data)
+
+	type test struct {
+		in     int64
+		whence int
+		out    int64
+	}
+	var tests = []test{
+		{0, 1, int64(len(data))},
+		{0, 0, 0},
+		{5, 0, 5},
+		{0, 2, int64(len(data))},
+		{0, 0, 0},
+		{-1, 2, int64(len(data)) - 1},
+		{1 << 33, 0, 1 << 33},
+		{1 << 33, 2, 1<<33 + int64(len(data))},
+	}
+	for i, tt := range tests {
+		off, err := f.Seek(tt.in, tt.whence)
+		if off != tt.out || err != nil {
+			if e, ok := err.(*os.PathError); ok && e.Err == syscall.EINVAL && tt.out > 1<<32 {
+				// Reiserfs rejects the big seeks.
+				// http://code.google.com/p/go/issues/detail?id=91
+				break
+			}
+			t.Errorf("#%d: Seek(%v, %v) = %v, %v want %v, nil", i, tt.in, tt.whence, off, err, tt.out)
+		}
+	}
+}
+
+func ReadAt(t *testing.T, fs afero.Fs) {
+	f := mustTempFile(fs)
+	defer f.Close()
+	defer fs.Remove(f.Name())
+
+	const data = "hello, world\n"
+	io.WriteString(f, data)
+
+	b := make([]byte, 5)
+	n, err := f.ReadAt(b, 7)
+	if err != nil || n != len(b) {
+		t.Fatalf("ReadAt 7: %d, %v", n, err)
+	}
+	if string(b) != "world" {
+		t.Fatalf("ReadAt 7: have %q want %q", string(b), "world")
+	}
+}
+
+func WriteAt(t *testing.T, fs afero.Fs) {
+	f := mustTempFile(fs)
+	defer f.Close()
+	defer fs.Remove(f.Name())
+
+	const data = "hello, world\n"
+	io.WriteString(f, data)
+
+	n, err := f.WriteAt([]byte("WORLD"), 7)
+	if err != nil || n != 5 {
+		t.Fatalf("WriteAt 7: %d, %v", n, err)
+	}
+
+	f2, err := fs.Open(f.Name())
+	defer f2.Close()
+	buf := new(bytes.Buffer)
+	buf.ReadFrom(f2)
+	b := buf.Bytes()
+	if err != nil {
+		t.Fatalf("%v: ReadFile %s: %v", fs.Name(), f.Name(), err)
+	}
+	if string(b) != "hello, WORLD\n" {
+		t.Fatalf("after write: have %q want %q", string(b), "hello, WORLD\n")
+	}
+}
+
+func setupTestFiles(t *testing.T, fs afero.Fs, path string) string {
+	testSubDir := filepath.Join(path, "more", "subdirectories", "for", "testing", "we")
+	err := fs.MkdirAll(testSubDir, 0700)
+	if err != nil && !os.IsExist(err) {
+		t.Fatal(err)
+	}
+
+	f, err := fs.Create(filepath.Join(testSubDir, "testfile1"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.WriteString("Testfile 1 content")
+	f.Close()
+
+	f, err = fs.Create(filepath.Join(testSubDir, "testfile2"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.WriteString("Testfile 2 content")
+	f.Close()
+
+	f, err = fs.Create(filepath.Join(testSubDir, "testfile3"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.WriteString("Testfile 3 content")
+	f.Close()
+
+	f, err = fs.Create(filepath.Join(testSubDir, "testfile4"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.WriteString("Testfile 4 content")
+	f.Close()
+	return testSubDir
+}
+
+func Readdirnames(t *testing.T, fs afero.Fs) {
+	tmpDir := mustTempDir(fs)
+	defer fs.RemoveAll(tmpDir)
+	testSubDir := setupTestFiles(t, fs, tmpDir)
+	tDir := filepath.Dir(testSubDir)
+
+	root, err := fs.Open(tDir)
+	if err != nil {
+		t.Fatal(fs.Name(), tDir, err)
+	}
+	defer root.Close()
+
+	namesRoot, err := root.Readdirnames(-1)
+	if err != nil {
+		t.Fatal(fs.Name(), namesRoot, err)
+	}
+
+	sub, err := fs.Open(testSubDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sub.Close()
+
+	namesSub, err := sub.Readdirnames(-1)
+	if err != nil {
+		t.Fatal(fs.Name(), namesSub, err)
+	}
+
+	findNames(fs, t, tDir, testSubDir, namesRoot, namesSub)
+}
+
+func ReaddirSimple(t *testing.T, fs afero.Fs) {
+	tmpDir := mustTempDir(fs)
+	defer fs.RemoveAll(tmpDir)
+	testSubDir := setupTestFiles(t, fs, tmpDir)
+	tDir := filepath.Dir(testSubDir)
+
+	root, err := fs.Open(tDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer root.Close()
+
+	rootInfo, err := root.Readdir(1)
+	if err != nil {
+		t.Log(myFileInfo(rootInfo))
+		t.Error(err)
+	}
+
+	rootInfo, err = root.Readdir(5)
+	if err != io.EOF {
+		t.Log(myFileInfo(rootInfo))
+		t.Errorf("%s second readdir should have been io.EOF, got %s", root.Name(), err)
+	}
+
+	sub, err := fs.Open(testSubDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sub.Close()
+
+	subInfo, err := sub.Readdir(5)
+	if err != nil {
+		t.Log(myFileInfo(subInfo))
+		t.Error(err)
+	}
+}
+
+type myFileInfo []os.FileInfo
+
+func (m myFileInfo) String() string {
+	out := "Fileinfos:\n"
+	for _, e := range m {
+		out += "  " + e.Name() + "\n"
+	}
+	return out
+}
+
+func ReaddirAll(t *testing.T, fs afero.Fs) {
+	tmpDir := mustTempDir(fs)
+	defer fs.RemoveAll(tmpDir)
+	testSubDir := setupTestFiles(t, fs, tmpDir)
+	tDir := filepath.Dir(testSubDir)
+
+	root, err := fs.Open(tDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer root.Close()
+
+	rootInfo, err := root.Readdir(-1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var namesRoot = []string{}
+	for _, e := range rootInfo {
+		namesRoot = append(namesRoot, e.Name())
+	}
+
+	sub, err := fs.Open(testSubDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sub.Close()
+
+	subInfo, err := sub.Readdir(-1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var namesSub = []string{}
+	for _, e := range subInfo {
+		namesSub = append(namesSub, e.Name())
+	}
+
+	findNames(fs, t, tDir, testSubDir, namesRoot, namesSub)
+}
+
+func StatDirectory(t *testing.T, fs afero.Fs) {
+	tmpDir := mustTempDir(fs)
+	defer fs.RemoveAll(tmpDir)
+	dirName := setupTestFiles(t, fs, tmpDir)
+
+	for _, validStatInput := range []string{
+		dirName,
+		dirName + "/",
+		dirName + "//",
+		"/" + dirName,
+	} {
+		dirStat, err := fs.Stat(validStatInput)
+		if err != nil {
+			t.Fatalf("could not stat %s: %s", validStatInput, err)
+		}
+		if expected := filepath.Base(dirName); dirStat.Name() != expected {
+			t.Fatalf("valid stat input: %s got Name %s, expected %s",
+				validStatInput, dirStat.Name(), expected)
+		}
+		if !dirStat.IsDir() {
+			t.Fatalf("valid stat input: %s got IsDir false for directory",
+				validStatInput)
+		}
+	}
+
+	for _, invalidStatInput := range []string{
+		dirName + "doesntexist",
+		dirName + "doesntexist/",
+		dirName + "/doesntexist",
+		dirName + "/doesntexist/",
+	} {
+		if _, err := fs.Stat(invalidStatInput); err == nil {
+			t.Fatalf("invalid stat input: %s no error returned for non-existent directory",
+				invalidStatInput)
+		} else if !os.IsNotExist(err) {
+			t.Fatalf("invalid stat input: %s error returned from Stat does not pass `os.IsNotExist` test: %s",
+				invalidStatInput, err)
+		}
+	}
+}
+
+func StatFile(t *testing.T, fs afero.Fs) {
+	f := mustTempFile(fs)
+	defer f.Close()
+	defer fs.Remove(f.Name())
+	fileName := f.Name()
+	for _, validStatInput := range []string{
+		fileName,
+		"/" + fileName,
+	} {
+		fileStat, err := fs.Stat(validStatInput)
+		if err != nil {
+			t.Errorf("could not stat %s: %s", validStatInput, err)
+			continue
+		}
+		if expected := filepath.Base(fileName); fileStat.Name() != expected {
+			t.Errorf("valid stat input: %s got Name %s, expected %s",
+				validStatInput, fileStat.Name(), expected)
+		}
+		if fileStat.IsDir() {
+			t.Errorf("valid stat input: %s got IsDir true for file",
+				validStatInput)
+		}
+	}
+
+	for _, invalidStatInput := range []string{
+		fileName + "doesntexist",
+		fileName + "doesntexist/",
+		fileName + "/",
+	} {
+		if _, err := fs.Stat(invalidStatInput); err == nil {
+			t.Errorf("invalid stat input: %s no error returned for non-existent file",
+				invalidStatInput)
+		} else if !os.IsNotExist(err) {
+			t.Fatalf("invalid stat input: %s error returned from Stat does not pass `os.IsNotExist` test: %s",
+				invalidStatInput, err)
+		}
+	}
+}
+
+func findNames(fs afero.Fs, t *testing.T, tDir, testSubDir string, root, sub []string) {
+	var foundRoot bool
+	for _, e := range root {
+		f, err := fs.Open(filepath.Join(tDir, e))
+		if err != nil {
+			t.Error("Open", filepath.Join(tDir, e), ":", err)
+		}
+		defer f.Close()
+
+		if equal(e, "we") {
+			foundRoot = true
+		}
+	}
+	if !foundRoot {
+		t.Logf("Names root: %v", root)
+		t.Logf("Names sub: %v", sub)
+		t.Error("Didn't find subdirectory we")
+	}
+
+	var found1, found2 bool
+	for _, e := range sub {
+		f, err := fs.Open(filepath.Join(testSubDir, e))
+		if err != nil {
+			t.Error("Open", filepath.Join(testSubDir, e), ":", err)
+		}
+		defer f.Close()
+
+		if equal(e, "testfile1") {
+			found1 = true
+		}
+		if equal(e, "testfile2") {
+			found2 = true
+		}
+	}
+
+	if !found1 {
+		t.Logf("Names root: %v", root)
+		t.Logf("Names sub: %v", sub)
+		t.Error("Didn't find testfile1")
+	}
+	if !found2 {
+		t.Logf("Names root: %v", root)
+		t.Logf("Names sub: %v", sub)
+		t.Error("Didn't find testfile2")
+	}
+}
+
+func equal(name1, name2 string) (r bool) {
+	switch runtime.GOOS {
+	case "windows":
+		r = strings.ToLower(name1) == strings.ToLower(name2)
+	default:
+		r = name1 == name2
+	}
+	return
+}
+
+func checkSize(t *testing.T, f afero.File, size int64) {
+	dir, err := f.Stat()
+	if err != nil {
+		t.Fatalf("Stat %q (looking for size %d): %s", f.Name(), size, err)
+	}
+	if dir.Size() != size {
+		t.Errorf("Stat %q: size %d want %d", f.Name(), dir.Size(), size)
+	}
+}


### PR DESCRIPTION
This is a mostly-working/mostly-tested implementation of S3 as an FS.

There are some gaps in the implementation, but it is otherwise pretty functional:
- It doesn't support non-offset == 0 reads or writes
- It doesn't support Truncate
- It doesn't support `Seek` with whence set to 2
- It doesn't support opening a file in append mode

All of these things increase the complexity of the implementation significantly (some are questionably well-defined, e.g. append in an eventually-consistent FS like S3), so for now I've left them out.

In order to reduce clutter in the root package `github.com/spf13/afero`, I put the whole implementation + tests in a sub package, `github.com/spf13/afero/s3`. In order to leverage the generic `Fs` tests in `afero_test.go`, I copy-pasted them into a sub package `github.com/spf13/afero/tests`. I also added a few tests to this file as I went along.

In order to run the tests you must pass a bucket: `go test -v github.com/spf13/afero/s3 -s3bucket <test bucket>`. You also need to set `AWS_REGION`, `AWS_ACCESS_KEY_ID`, and `AWS_SECRET_ACCESS_KEY`.

Let me know what you think 😄 
