### PR TITLE
Fixed utility function calls in testing example

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,8 +201,8 @@ func TestExist(t *testing.T) {
 	appFS = afero.NewMemMapFs()
 	// create test files and directories
 	appFS.MkdirAll("src/a", 0755))
-	appFS.WriteFile("src/a/b", []byte("file b"), 0644)
-	appFS.WriteFile("src/c", []byte("file c"), 0644)
+	afero.WriteFile(appFS, "src/a/b", []byte("file b"), 0644)
+	afero.WriteFile(appFS, "src/c", []byte("file c"), 0644)
 	_, err := appFS.Stat("src/c")
 	if os.IsNotExist(err) {
         t.Errorf("file \"%s\" does not exist.\n", name)


### PR DESCRIPTION
Hi there,

I found some small typos in the testing example on the README. The calls to `WriteFile()` should follow the conventions as shown in the utility functions section in the README, instead of being called directly on the appFS variable (as it does not have a `WriteFile()` method).

Let me know if I'm just not understanding the example correctly, as that is entirely possible. :)