### PR TITLE
Fixes a data race caused by not locking the mem.FileData for read access.

### DIFF
--- a/mem/file.go
+++ b/mem/file.go
@@ -107,6 +107,8 @@ func (f *File) Close() error {
 }
 
 func (f *File) Name() string {
+	f.fileData.Lock()
+	defer f.fileData.Unlock()
 	return f.fileData.name
 }
 


### PR DESCRIPTION
For example, as seen in : https://travis-ci.org/google/mtail/jobs/153781970