### PR TITLE
fixes typo in RemoveAll code comment

### DIFF
--- a/afero.go
+++ b/afero.go
@@ -77,7 +77,7 @@ type Fs interface {
 	// happens.
 	Remove(name string) error
 
-	// RemoveAll removes a directory path and all any children it contains. It
+	// RemoveAll removes a directory path and any children it contains. It
 	// does not fail if the path does not exist (return nil).
 	RemoveAll(path string) error
 


### PR DESCRIPTION
I wasn't sure if I should remove the `all` or the `any`. Opted for `all` because of other use cases.
