### PR TITLE
Handle relative paths in MemMapFs

### DIFF
--- a/memmap.go
+++ b/memmap.go
@@ -154,16 +154,7 @@ func (m *MemMapFs) MkdirAll(path string, perm os.FileMode) error {
 
 // Handle some relative paths
 func normalizePath(path string) string {
-	path = filepath.Clean(path)
-
-	switch path {
-	case ".":
-		return FilePathSeparator
-	case "..":
-		return FilePathSeparator
-	default:
-		return path
-	}
+	return filepath.Clean(FilePathSeparator + path)
 }
 
 func (m *MemMapFs) Open(name string) (File, error) {


### PR DESCRIPTION
This fixes the problem where mixing relative and absolute paths in the same
FS caused a strange error with `Walk`:

```go
vfs := afero.Afero{Fs: afero.NewMemMapFs()}
vfs.Mkdir("/tmp", 0777)
vfs.MkdirAll("src/a", 0755)

vfs.Walk("/", func(path string, info os.FileInfo, err error) error {
  if err != nil {
    panic(err)
  }
  return nil
})
```

(In this example I am just using `panic` as a short cut.)

The error message was `open /src: file does not exist` but as far as I
could see I had created `/src`. The problem was that some paths were
being made absolute but not all. With this patch the error goes away,
and all paths are absolute.