### PR TITLE
Set perm in MemMapFS after OpenFile, MkDir and MkDirAll methods called

### DIFF
--- a/memmap_test.go
+++ b/memmap_test.go
@@ -102,6 +102,67 @@ func checkPathError(t *testing.T, err error, op string) {
 	}
 }
 
+// Ensure Permissions are set on OpenFile/Mkdir/MkdirAll
+func TestPermSet(t *testing.T) {
+	const fileName = "/myFileTest"
+	const dirPath =  "/myDirTest"
+	const dirPathAll =  "/my/path/to/dir"
+
+	const fileMode = os.FileMode(0765)
+
+	fs := NewMemMapFs()
+
+	// Test Openfile
+	f, err := fs.OpenFile(fileName, os.O_CREATE, fileMode)
+	if err != nil {
+		t.Errorf("OpenFile Create failed: %s", err)
+		return
+	}
+	f.Close()
+
+	s, err := fs.Stat(fileName)
+	if err != nil {
+		t.Errorf("Stat failed: %s", err)
+		return
+	}
+	if s.Mode().String() != fileMode.String() {
+		t.Errorf("Permissions Incorrect: %s != %s", s.Mode().String(), fileMode.String())
+		return
+	}
+
+	// Test Mkdir
+	err = fs.Mkdir(dirPath, fileMode)
+	if err != nil {
+		t.Errorf("MkDir Create failed: %s", err)
+		return
+	}
+	s, err = fs.Stat(dirPath)
+	if err != nil {
+		t.Errorf("Stat failed: %s", err)
+		return
+	}
+	if s.Mode().String() != fileMode.String() {
+		t.Errorf("Permissions Incorrect: %s != %s", s.Mode().String(), fileMode.String())
+		return
+	}
+
+	// Test MkdirAll
+	err = fs.MkdirAll(dirPathAll, fileMode)
+	if err != nil {
+		t.Errorf("MkDir Create failed: %s", err)
+		return
+	}
+	s, err = fs.Stat(dirPathAll)
+	if err != nil {
+		t.Errorf("Stat failed: %s", err)
+		return
+	}
+	if s.Mode().String() != fileMode.String() {
+		t.Errorf("Permissions Incorrect: %s != %s", s.Mode().String(), fileMode.String())
+		return
+	}
+}
+
 // Fails if multiple file objects use the same file.at counter in MemMapFs
 func TestMultipleOpenFiles(t *testing.T) {
 	defer removeAllTestFiles(t)


### PR DESCRIPTION
With MemMapFS the perm parameter is ignored with OpenFile, MkDir and MkDirAll

Tests added and run successfully.

Addresses Issue #107 