### PR TITLE
Properly set directory file mode in memory mapped file systems

### DIFF
--- a/mem/file.go
+++ b/mem/file.go
@@ -70,7 +70,7 @@ func CreateFile(name string) *FileData {
 }
 
 func CreateDir(name string) *FileData {
-	return &FileData{name: name, memDir: &DirMap{}, dir: true}
+	return &FileData{name: name, mode: os.ModeDir, memDir: &DirMap{}, dir: true}
 }
 
 func ChangeFileName(f *FileData, newname string) {


### PR DESCRIPTION
Previously, `mem.CreateDir` in mem/file.go neglected to set
the `mode` field of the new `FileData` struct. This led to other
libraries believing that memory mapped directories were regular
files, causing unexpected errors.

An example of this occurs in the standard library package
`archive/tar`. If a `tar.Header` was constructed with the function
`tar.FileInfoHeader` for a memory mapped directory, writing it
will error because it is treated like a regular file (and thus
bytes are expected to be written).