### PR TITLE
Remove syscall package dependency for AppEngine

### DIFF
--- a/afero_test.go
+++ b/afero_test.go
@@ -23,7 +23,6 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
-	"syscall"
 	"testing"
 )
 
@@ -345,7 +344,7 @@ func TestSeek(t *testing.T) {
 		for i, tt := range tests {
 			off, err := f.Seek(tt.in, tt.whence)
 			if off != tt.out || err != nil {
-				if e, ok := err.(*os.PathError); ok && e.Err == syscall.EINVAL && tt.out > 1<<32 {
+				if e, ok := err.(*os.PathError); ok && e.Err == EINVAL && tt.out > 1<<32 {
 					// Reiserfs rejects the big seeks.
 					// http://code.google.com/p/go/issues/detail?id=91
 					break

--- a/cacheOnReadFs.go
+++ b/cacheOnReadFs.go
@@ -2,7 +2,6 @@ package afero
 
 import (
 	"os"
-	"syscall"
 	"time"
 )
 
@@ -64,7 +63,7 @@ func (u *CacheOnReadFs) cacheStatus(name string) (state cacheState, fi os.FileIn
 		return cacheHit, lfi, nil
 	}
 
-	if err == syscall.ENOENT {
+	if err == ENOENT {
 		return cacheMiss, nil, nil
 	}
 	var ok bool
@@ -200,7 +199,7 @@ func (u *CacheOnReadFs) OpenFile(name string, flag int, perm os.FileMode) (File,
 			return nil, err
 		}
 	}
-	if flag&(os.O_WRONLY|syscall.O_RDWR|os.O_APPEND|os.O_CREATE|os.O_TRUNC) != 0 {
+	if flag&(os.O_WRONLY|O_RDWR|os.O_APPEND|os.O_CREATE|os.O_TRUNC) != 0 {
 		bfi, err := u.base.OpenFile(name, flag, perm)
 		if err != nil {
 			return nil, err

--- a/const.go
+++ b/const.go
@@ -10,11 +10,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// +build !darwin
-// +build !openbsd
-// +build !freebsd
-// +build !dragonfly
-// +build !netbsd
+
 // +build !appengine
 
 package afero
@@ -23,4 +19,11 @@ import (
 	"syscall"
 )
 
-const BADFD = syscall.EBADFD
+const EPERM = syscall.EPERM
+const ENOENT = syscall.ENOENT
+const EIO = syscall.EIO
+const EEXIST = syscall.EEXIST
+const ENOTDIR = syscall.ENOTDIR
+const EINVAL = syscall.EINVAL
+
+const O_RDWR = syscall.O_RDWR

--- a/const_appengine.go
+++ b/const_appengine.go
@@ -10,17 +10,34 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// +build !darwin
-// +build !openbsd
-// +build !freebsd
-// +build !dragonfly
-// +build !netbsd
-// +build !appengine
+
+// +build appengine
 
 package afero
 
 import (
-	"syscall"
+	"strconv"
 )
 
-const BADFD = syscall.EBADFD
+// An Errno is an unsigned number describing an error condition.
+// It implements the error interface. The zero Errno is by convention
+// a non-error, so code to convert from Errno to error should use:
+//	err = nil
+//	if errno != 0 {
+//		err = errno
+//	}
+type Errno uintptr
+
+func (e Errno) Error() string {
+	return "errno " + strconv.Itoa(int(e))
+}
+
+const EPERM = Errno(0x1)
+const ENOENT = Errno(0x2)
+const EIO = Errno(0x5)
+const EEXIST = Errno(0x11)
+const ENOTDIR = Errno(0x14)
+const EINVAL = Errno(0x16)
+const BADFD = Errno(0x4d)
+
+const O_RDWR = 0x2

--- a/const_bsds.go
+++ b/const_bsds.go
@@ -12,6 +12,7 @@
 // limitations under the License.
 
 // +build darwin openbsd freebsd netbsd dragonfly
+// +build !appengine
 
 package afero
 

--- a/copyOnWriteFs.go
+++ b/copyOnWriteFs.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"syscall"
 	"time"
 )
 
@@ -32,11 +31,11 @@ func (u *CopyOnWriteFs) isBaseFile(name string) (bool, error) {
 	_, err := u.base.Stat(name)
 	if err != nil {
 		if oerr, ok := err.(*os.PathError); ok {
-			if oerr.Err == os.ErrNotExist || oerr.Err == syscall.ENOENT || oerr.Err == syscall.ENOTDIR {
+			if oerr.Err == os.ErrNotExist || oerr.Err == ENOENT || oerr.Err == ENOTDIR {
 				return false, nil
 			}
 		}
-		if err == syscall.ENOENT {
+		if err == ENOENT {
 			return false, nil
 		}
 	}
@@ -80,7 +79,7 @@ func (u *CopyOnWriteFs) Stat(name string) (os.FileInfo, error) {
 		if e, ok := err.(*os.PathError); ok {
 			err = e.Err
 		}
-		if err == syscall.ENOENT || err == syscall.ENOTDIR {
+		if err == ENOENT || err == ENOTDIR {
 			return u.base.Stat(name)
 		}
 		return nil, origErr
@@ -95,7 +94,7 @@ func (u *CopyOnWriteFs) Rename(oldname, newname string) error {
 		return err
 	}
 	if b {
-		return syscall.EPERM
+		return EPERM
 	}
 	return u.layer.Rename(oldname, newname)
 }
@@ -106,12 +105,12 @@ func (u *CopyOnWriteFs) Rename(oldname, newname string) error {
 func (u *CopyOnWriteFs) Remove(name string) error {
 	err := u.layer.Remove(name)
 	switch err {
-	case syscall.ENOENT:
+	case ENOENT:
 		_, err = u.base.Stat(name)
 		if err == nil {
-			return syscall.EPERM
+			return EPERM
 		}
-		return syscall.ENOENT
+		return ENOENT
 	default:
 		return err
 	}
@@ -120,12 +119,12 @@ func (u *CopyOnWriteFs) Remove(name string) error {
 func (u *CopyOnWriteFs) RemoveAll(name string) error {
 	err := u.layer.RemoveAll(name)
 	switch err {
-	case syscall.ENOENT:
+	case ENOENT:
 		_, err = u.base.Stat(name)
 		if err == nil {
-			return syscall.EPERM
+			return EPERM
 		}
-		return syscall.ENOENT
+		return ENOENT
 	default:
 		return err
 	}
@@ -165,7 +164,7 @@ func (u *CopyOnWriteFs) OpenFile(name string, flag int, perm os.FileMode) (File,
 			return u.layer.OpenFile(name, flag, perm)
 		}
 
-		return nil, &os.PathError{Op: "open", Path: name, Err: syscall.ENOTDIR} // ...or os.ErrNotExist?
+		return nil, &os.PathError{Op: "open", Path: name, Err: ENOTDIR} // ...or os.ErrNotExist?
 	}
 	if b {
 		return u.base.OpenFile(name, flag, perm)
@@ -228,7 +227,7 @@ func (u *CopyOnWriteFs) Mkdir(name string, perm os.FileMode) error {
 		return u.layer.MkdirAll(name, perm)
 	}
 	if dir {
-		return syscall.EEXIST
+		return EEXIST
 	}
 	return u.layer.MkdirAll(name, perm)
 }
@@ -243,7 +242,7 @@ func (u *CopyOnWriteFs) MkdirAll(name string, perm os.FileMode) error {
 		return u.layer.MkdirAll(name, perm)
 	}
 	if dir {
-		return syscall.EEXIST
+		return EEXIST
 	}
 	return u.layer.MkdirAll(name, perm)
 }

--- a/readonlyfs.go
+++ b/readonlyfs.go
@@ -2,7 +2,6 @@ package afero
 
 import (
 	"os"
-	"syscall"
 	"time"
 )
 
@@ -19,11 +18,11 @@ func (r *ReadOnlyFs) ReadDir(name string) ([]os.FileInfo, error) {
 }
 
 func (r *ReadOnlyFs) Chtimes(n string, a, m time.Time) error {
-	return syscall.EPERM
+	return EPERM
 }
 
 func (r *ReadOnlyFs) Chmod(n string, m os.FileMode) error {
-	return syscall.EPERM
+	return EPERM
 }
 
 func (r *ReadOnlyFs) Name() string {
@@ -35,20 +34,20 @@ func (r *ReadOnlyFs) Stat(name string) (os.FileInfo, error) {
 }
 
 func (r *ReadOnlyFs) Rename(o, n string) error {
-	return syscall.EPERM
+	return EPERM
 }
 
 func (r *ReadOnlyFs) RemoveAll(p string) error {
-	return syscall.EPERM
+	return EPERM
 }
 
 func (r *ReadOnlyFs) Remove(n string) error {
-	return syscall.EPERM
+	return EPERM
 }
 
 func (r *ReadOnlyFs) OpenFile(name string, flag int, perm os.FileMode) (File, error) {
-	if flag&(os.O_WRONLY|syscall.O_RDWR|os.O_APPEND|os.O_CREATE|os.O_TRUNC) != 0 {
-		return nil, syscall.EPERM
+	if flag&(os.O_WRONLY|O_RDWR|os.O_APPEND|os.O_CREATE|os.O_TRUNC) != 0 {
+		return nil, EPERM
 	}
 	return r.source.OpenFile(name, flag, perm)
 }
@@ -58,13 +57,13 @@ func (r *ReadOnlyFs) Open(n string) (File, error) {
 }
 
 func (r *ReadOnlyFs) Mkdir(n string, p os.FileMode) error {
-	return syscall.EPERM
+	return EPERM
 }
 
 func (r *ReadOnlyFs) MkdirAll(n string, p os.FileMode) error {
-	return syscall.EPERM
+	return EPERM
 }
 
 func (r *ReadOnlyFs) Create(n string) (File, error) {
-	return nil, syscall.EPERM
+	return nil, EPERM
 }

--- a/regexpfs.go
+++ b/regexpfs.go
@@ -3,7 +3,6 @@ package afero
 import (
 	"os"
 	"regexp"
-	"syscall"
 	"time"
 )
 
@@ -32,7 +31,7 @@ func (r *RegexpFs) matchesName(name string) error {
 	if r.re.MatchString(name) {
 		return nil
 	}
-	return syscall.ENOENT
+	return ENOENT
 }
 
 func (r *RegexpFs) dirOrMatches(name string) error {

--- a/unionFile.go
+++ b/unionFile.go
@@ -4,7 +4,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"syscall"
 )
 
 // The UnionFile implements the afero.File interface and will be returned
@@ -261,7 +260,7 @@ func copyToLayer(base Fs, layer Fs, name string) error {
 	if err != nil || bfi.Size() != n {
 		layer.Remove(name)
 		lfh.Close()
-		return syscall.EIO
+		return EIO
 	}
 
 	err = lfh.Close()


### PR DESCRIPTION
Moves dependencies into a separate const.go file that can be build tagged out.

An alternative, non syscall referencing file can then be used to make the package usable on appengine (with https://github.com/captaincodeman/afero-datastore)