### PR TITLE
readme: remove inferred type from AppFs declaration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,11 +61,11 @@ import "github.com/spf13/afero"
 
 First define a package variable and set it to a pointer to a filesystem.
 ```go
-var AppFs afero.Fs = afero.NewMemMapFs()
+var AppFs = afero.NewMemMapFs()
 
 or
 
-var AppFs afero.Fs = afero.NewOsFs()
+var AppFs = afero.NewOsFs()
 ```
 It is important to note that if you repeat the composite literal you
 will be using a completely new and isolated filesystem. In the case of


### PR DESCRIPTION
AppFs type is inferred from afero.NewOsFs(), go lint tools are complaining about expliciting the type.

> should omit type afero.Fs from declaration of var AppFs; it will be inferred from the right-hand side (golint)