### PR TITLE
Fix failure of the cache miss processing

### DIFF
--- a/cacheOnReadFs.go
+++ b/cacheOnReadFs.go
@@ -67,9 +67,8 @@ func (u *CacheOnReadFs) cacheStatus(name string) (state cacheState, fi os.FileIn
 	if err == syscall.ENOENT {
 		return cacheMiss, nil, nil
 	}
-	var ok bool
-	if err, ok = err.(*os.PathError); ok {
-		if err == os.ErrNotExist {
+	if err, ok := err.(*os.PathError); ok {
+		if err.Err == os.ErrNotExist {
 			return cacheMiss, nil, nil
 		}
 	}


### PR DESCRIPTION
Error was not properly checked. I guess it's a simple typo. As the result instead of processing the error as the special cache-miss case, it was returning the underlying error up to the caller.