### PR TITLE
Fix data races in MemMapFs

### DIFF
--- a/memmap.go
+++ b/memmap.go
@@ -66,7 +66,10 @@ func (m *MemMapFs) unRegisterWithParent(fileName string) error {
 	if parent == nil {
 		log.Panic("parent of ", f.Name(), " is nil")
 	}
+
+	parent.Lock()
 	mem.RemoveFromMemDir(parent, f)
+	parent.Unlock()
 	return nil
 }
 
@@ -99,8 +102,10 @@ func (m *MemMapFs) registerWithParent(f *mem.FileData) {
 		}
 	}
 
+	parent.Lock()
 	mem.InitializeDir(parent)
 	mem.AddToMemDir(parent, f)
+	parent.Unlock()
 }
 
 func (m *MemMapFs) lockfreeMkdir(name string, perm os.FileMode) error {


### PR DESCRIPTION
Concurrent modifications of the file system while calling
ReadDir was causing data races and sometimes panics.