### PR TITLE
CacheOnReadFS: erroneous NotExists error from MemMapFS layer

### DIFF
--- a/cacheOnReadFs.go
+++ b/cacheOnReadFs.go
@@ -64,15 +64,10 @@ func (u *CacheOnReadFs) cacheStatus(name string) (state cacheState, fi os.FileIn
 		return cacheHit, lfi, nil
 	}
 
-	if err == syscall.ENOENT {
+	if err == syscall.ENOENT || os.IsNotExist(err) {
 		return cacheMiss, nil, nil
 	}
-	var ok bool
-	if err, ok = err.(*os.PathError); ok {
-		if err == os.ErrNotExist {
-			return cacheMiss, nil, nil
-		}
-	}
+
 	return cacheMiss, nil, err
 }
 

--- a/composite_test.go
+++ b/composite_test.go
@@ -1,6 +1,7 @@
 package afero
 
 import (
+	"bytes"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -365,4 +366,39 @@ func TestUnionCacheExpire(t *testing.T) {
 	if string(data) != "Another test" {
 		t.Errorf("cache time failed: <%s>", data)
 	}
+}
+
+func TestCacheOnReadFs_Open_NotInLayer(t *testing.T) {
+	base := NewMemMapFs()
+	layer := NewMemMapFs()
+	fs := NewCacheOnReadFs(base, layer, 0)
+
+	fh, err := base.Create("/file.txt")
+	if err != nil {
+		t.Fatal("unable to create file: ", err)
+	}
+
+	txt := []byte("This is a test")
+	fh.Write(txt)
+	fh.Close()
+
+	fh, err = fs.Open("/file.txt")
+	if err != nil {
+		t.Fatal("could not open file: ", err)
+	}
+
+	b, err := ReadAll(fh)
+	fh.Close()
+
+	if err != nil {
+		t.Fatal("could not read file: ", err)
+	} else if !bytes.Equal(txt, b) {
+		t.Fatalf("wanted file text %q, got %q", txt, b)
+	}
+
+	fh, err = layer.Open("/file.txt")
+	if err != nil {
+		t.Fatal("could not open file from layer: ", err)
+	}
+	fh.Close()
 }


### PR DESCRIPTION
CacheOnReadFS erroneously returns a NotExists error even if the file is available in the base FS. This first commit demonstrates this error with a test. The following will include a fix.