### PR TITLE
Always return the concrete type instead of the Fs interface

### DIFF
--- a/basepath.go
+++ b/basepath.go
@@ -22,7 +22,10 @@ type BasePathFs struct {
 	path   string
 }
 
-func NewBasePathFs(source Fs, path string) Fs {
+// Check if BasePathFs implements Fs
+var _ Fs = &BasePathFs{}
+
+func NewBasePathFs(source Fs, path string) *BasePathFs {
 	return &BasePathFs{source: source, path: path}
 }
 

--- a/basepath_test.go
+++ b/basepath_test.go
@@ -51,7 +51,7 @@ func TestRealPath(t *testing.T) {
 	}
 	defer fs.RemoveAll(anotherDir)
 
-	bp := NewBasePathFs(fs, baseDir).(*BasePathFs)
+	bp := NewBasePathFs(fs, baseDir)
 
 	subDir := filepath.Join(baseDir, "s1")
 

--- a/cacheOnReadFs.go
+++ b/cacheOnReadFs.go
@@ -25,7 +25,10 @@ type CacheOnReadFs struct {
 	cacheTime time.Duration
 }
 
-func NewCacheOnReadFs(base Fs, layer Fs, cacheTime time.Duration) Fs {
+// Check if CacheOnReadFs implements Fs
+var _ Fs = &CacheOnReadFs{}
+
+func NewCacheOnReadFs(base Fs, layer Fs, cacheTime time.Duration) *CacheOnReadFs {
 	return &CacheOnReadFs{base: base, layer: layer, cacheTime: cacheTime}
 }
 

--- a/copyOnWriteFs.go
+++ b/copyOnWriteFs.go
@@ -20,7 +20,10 @@ type CopyOnWriteFs struct {
 	layer Fs
 }
 
-func NewCopyOnWriteFs(base Fs, layer Fs) Fs {
+// Check if CopyOnWriteFs implements Fs
+var _ Fs = &CopyOnWriteFs{}
+
+func NewCopyOnWriteFs(base Fs, layer Fs) *CopyOnWriteFs {
 	return &CopyOnWriteFs{base: base, layer: layer}
 }
 

--- a/httpFs.go
+++ b/httpFs.go
@@ -49,6 +49,9 @@ type HttpFs struct {
 	source Fs
 }
 
+// Check if HttpFs implements http.FileSystem
+var _ http.FileSystem = &HttpFs{}
+
 func NewHttpFs(source Fs) *HttpFs {
 	return &HttpFs{source: source}
 }

--- a/memmap.go
+++ b/memmap.go
@@ -31,7 +31,10 @@ type MemMapFs struct {
 	init sync.Once
 }
 
-func NewMemMapFs() Fs {
+// Check if MemMapFs implements Fs
+var _ Fs = &MemMapFs{}
+
+func NewMemMapFs() *MemMapFs {
 	return &MemMapFs{}
 }
 

--- a/os.go
+++ b/os.go
@@ -25,8 +25,11 @@ import (
 // (http://golang.org/pkg/os/).
 type OsFs struct{}
 
-func NewOsFs() Fs {
-	return &OsFs{}
+// Check if OsFs implements Fs
+var _ Fs = OsFs{}
+
+func NewOsFs() OsFs {
+	return OsFs{}
 }
 
 func (OsFs) Name() string { return "OsFs" }

--- a/readonlyfs.go
+++ b/readonlyfs.go
@@ -10,7 +10,10 @@ type ReadOnlyFs struct {
 	source Fs
 }
 
-func NewReadOnlyFs(source Fs) Fs {
+// Check if ReadOnlyFs implements Fs
+var _ Fs = &ReadOnlyFs{}
+
+func NewReadOnlyFs(source Fs) *ReadOnlyFs {
 	return &ReadOnlyFs{source: source}
 }
 

--- a/regexpfs.go
+++ b/regexpfs.go
@@ -16,7 +16,10 @@ type RegexpFs struct {
 	source Fs
 }
 
-func NewRegexpFs(source Fs, re *regexp.Regexp) Fs {
+// Check if RegexpFs implements Fs
+var _ Fs = &RegexpFs{}
+
+func NewRegexpFs(source Fs, re *regexp.Regexp) *RegexpFs {
 	return &RegexpFs{source: source, re: re}
 }
 

--- a/sftpfs/sftp.go
+++ b/sftpfs/sftp.go
@@ -29,7 +29,10 @@ type Fs struct {
 	client *sftp.Client
 }
 
-func New(client *sftp.Client) afero.Fs {
+// Check if Fs implements afero.Fs
+var _ afero.Fs = &Fs{}
+
+func New(client *sftp.Client) *Fs {
 	return &Fs{client: client}
 }
 


### PR DESCRIPTION
Added `var _ afero.Fs = &Fs{}` style type checks to statically check if the interface is implemented.

These changes broke one test:
```diff
-	bp := NewBasePathFs(fs, baseDir).(*BasePathFs)
+	bp := NewBasePathFs(fs, baseDir)
```
This pattern is probably also found in code that uses this library, which makes this a breaking change. Details are discussed in #76.

fixes #76