### PR TITLE
Use more restrictive interface for SFTP

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,9 @@ sudo: false
 language: go
 
 go:
-  - 1.7.5
-  - 1.8
+  - 1.7.x
+  - 1.8.x
+  - 1.9.x
   - tip
 
 os:

--- a/sftpfs/file.go
+++ b/sftpfs/file.go
@@ -14,15 +14,14 @@
 package sftpfs
 
 import (
-	"github.com/pkg/sftp"
 	"os"
 )
 
 type File struct {
-	fd *sftp.File
+	fd SFTPFile
 }
 
-func FileOpen(s *sftp.Client, name string) (*File, error) {
+func FileOpen(s SFTPClient, name string) (*File, error) {
 	fd, err := s.Open(name)
 	if err != nil {
 		return &File{}, err
@@ -30,7 +29,7 @@ func FileOpen(s *sftp.Client, name string) (*File, error) {
 	return &File{fd: fd}, nil
 }
 
-func FileCreate(s *sftp.Client, name string) (*File, error) {
+func FileCreate(s SFTPClient, name string) (*File, error) {
 	fd, err := s.Create(name)
 	if err != nil {
 		return &File{}, err

--- a/sftpfs/sftp.go
+++ b/sftpfs/sftp.go
@@ -17,7 +17,6 @@ import (
 	"os"
 	"time"
 
-	"github.com/pkg/sftp"
 	"github.com/spf13/afero"
 )
 
@@ -26,10 +25,10 @@ import (
 // For details in any method, check the documentation of the sftp package
 // (github.com/pkg/sftp).
 type Fs struct {
-	client *sftp.Client
+	client SFTPClient
 }
 
-func New(client *sftp.Client) afero.Fs {
+func New(client SFTPClient) afero.Fs {
 	return &Fs{client: client}
 }
 

--- a/sftpfs/types.go
+++ b/sftpfs/types.go
@@ -1,0 +1,33 @@
+package sftpfs
+
+import (
+	"io"
+	"os"
+	"time"
+)
+
+// SFTPClient represents the interface to an SFTP Client.
+// The github.com/pkg/sftp package client implements this interface.
+type SFTPClient interface {
+	Mkdir(path string) error
+	Chmod(path string, mode os.FileMode) error
+	Remove(path string) error
+	Rename(oldname, newname string) error
+	Stat(p string) (os.FileInfo, error)
+	Lstat(p string) (os.FileInfo, error)
+	Chtimes(path string, atime time.Time, mtime time.Time) error
+	Create(path string) (SFTPFile, error)
+	Open(path string) (SFTPFile, error)
+}
+
+// SFTPFile represents the interface for a file accessed via the SFTPClient.
+type SFTPFile interface {
+	io.Reader
+	io.Writer
+	io.Seeker
+	io.Closer
+
+	Stat() (os.FileInfo, error)
+	Name() string
+	Truncate(size int64) error
+}


### PR DESCRIPTION
This uses a more restrictive interface for the SFTP client and removes the requirement that you use `github.com/pkg/sftp` directly, which is useful if you want to introduce SFTP middleware or use a different package as a client.

Once we do this though, the coupling is pretty loose, you could probably make this more generic and get rid of the fact that its SFTP at all, its basically just a provider without the ability to `ReaderAt` or `WriterAt` I think.