### PR TITLE
Mountable file system

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,21 +380,23 @@ MountableFs allows afero.Fs instances to be mounted at specific paths over the
 top of any existing afero.Fs, similar to a bind mount on a Unix filesystem. 
 
 ```go
-    base := afero.NewOsFs("/tmp")
+    base := afero.NewBasePathFs(afero.NewOsFs(), "/tmp")
     fs := afero.NewMountableFs(base)
 
     // mount child fs at path /child
     child := afero.NewMemMapFs()
     _ = fs.Mount("/child", child)
 
+    in := []byte("1")
+
     // write file to /child/test of mountable filesystem
-    afero.WriteFile(fs, "/child/test", []byte("1"), 0644)
+    afero.WriteFile(fs, "/child/test", in, 0644)
 
     // read file from /test of mounted filesystem
     out, _ := afero.ReadFile(child, "/test")
 
     // should print true
-    fmt.Println(reflect.DeepEqual(in, out))
+    fmt.Println(bytes.Equal(in, out))
 ```
 
 If a nil `Fs` is passed to the constructor (`NewMountableFs(nil)`), an

--- a/mountfs.go
+++ b/mountfs.go
@@ -1,3 +1,16 @@
+// Copyright © 2017 Blake Williams <code@shabbyrobe.org>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package afero
 
 import (

--- a/mountfs.go
+++ b/mountfs.go
@@ -255,7 +255,7 @@ func (m *MountableFs) Remove(name string) error {
 }
 
 func (m *MountableFs) RemoveAll(path string) error {
-	info, err := lstatIfOs(m, path)
+	info, err := lstatIfPossible(m, path)
 	if err != nil {
 		return wrapErrorPath(path, err)
 	}
@@ -644,7 +644,7 @@ func departWalk(fs Fs, path string, info os.FileInfo, walkFn filepath.WalkFunc) 
 
 		for _, name := range names {
 			filename := filepath.Join(path, name)
-			fileInfo, err := lstatIfOs(fs, filename)
+			fileInfo, err := lstatIfPossible(fs, filename)
 			if err != nil {
 				if err := walkFn(filename, fileInfo, err); err != nil {
 					return err

--- a/mountfs.go
+++ b/mountfs.go
@@ -344,8 +344,6 @@ func wrapErrorPath(path string, err error) error {
 	switch err := err.(type) {
 	case *os.PathError:
 		err.Path = path
-	default:
-		err = &os.PathError{Err: err, Path: path}
 	}
 	return err
 }

--- a/mountfs.go
+++ b/mountfs.go
@@ -1,0 +1,642 @@
+package afero
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// MountableFs allows different paths in a hierarchy to be served by different
+// afero.Fs objects.
+type MountableFs struct {
+	node                *mountableNode
+	AllowCrossFsRename  bool
+	AllowRecursiveMount bool
+	now                 func() time.Time
+}
+
+func NewMountableFs(base Fs) *MountableFs {
+	if base == nil {
+		base = NewMemMapFs()
+	}
+	mfs := &MountableFs{
+		now:  time.Now,
+		node: &mountableNode{fs: base, nodes: map[string]*mountableNode{}},
+	}
+	return mfs
+}
+
+// Mount an afero.Fs at the specified path.
+//
+// This will fail if there is already a Fs at the path, or
+// any existing mounted Fs contains a file at that path.
+//
+// You must wrap an afero.OsFs in an afero.BasePathFs to mount it,
+// even if that's just to dispose of the Windows drive letter.
+func (m *MountableFs) Mount(path string, fs Fs) error {
+	// No idea what to do with windows drive letters here, so force BasePathFs
+	if _, ok := fs.(*OsFs); ok {
+		return errOsFs
+	}
+
+	// If there is already an entry at this path that is not a mount node,
+	// Mount should fail.
+	info, err := m.Stat(path)
+	if err != nil && !os.IsNotExist(err) {
+		return wrapErrorPath(path, err)
+	} else {
+		err = nil
+	}
+	if info != nil && !IsMountNode(info) {
+		return &os.PathError{Err: os.ErrExist, Op: "Mount", Path: path}
+	}
+
+	parts := splitPath(path)
+
+	cur := m.node
+	for i, p := range parts {
+		var next *mountableNode
+		var ok bool
+		if next, ok = cur.nodes[p]; !ok {
+			next = &mountableNode{
+				nodes:   map[string]*mountableNode{},
+				parent:  cur,
+				name:    p,
+				depth:   i + 1,
+				modTime: m.now()}
+		}
+		if next.fs == fs && !m.AllowRecursiveMount {
+			return errRecursiveMount
+		}
+		cur.nodes[p] = next
+		cur = next
+	}
+	if cur.fs != nil {
+		return errAlreadyMounted
+	}
+	if cur.parent != nil {
+		cur.parent.mountedNodes++
+	}
+
+	cur.fs = fs
+	return nil
+}
+
+func (m *MountableFs) Umount(path string) error {
+	parts := splitPath(path)
+
+	cur := m.node
+	for _, p := range parts {
+		if next, ok := cur.nodes[p]; ok {
+			cur = next
+		} else {
+			return &os.PathError{Err: errNotMounted, Op: "Umount", Path: path}
+		}
+	}
+	if cur.fs == nil {
+		return &os.PathError{Err: errNotMounted, Op: "Umount", Path: path}
+	}
+
+	for cur != nil {
+		// Don't stuff around with the root node!
+		if cur.parent != nil {
+			cur.fs = nil
+			cur.parent.mountedNodes--
+			if len(cur.nodes) == 0 {
+				delete(cur.parent.nodes, cur.name)
+			}
+		}
+		cur = cur.parent
+	}
+
+	return nil
+}
+
+func (m *MountableFs) Remount(path string, fs Fs) error {
+	if err := m.Umount(path); err != nil {
+		return wrapErrorPath(path, err)
+	}
+	return m.Mount(path, fs)
+}
+
+func (m *MountableFs) Mkdir(name string, perm os.FileMode) error {
+	node := m.node.findNode(name)
+	if node != nil {
+		// if the path points to an intermediate node and the intermediate node
+		// doesn't mask a real directory on the underlying filesystem,
+		// make the directory inside the parent filesystem.
+		if exists, err := m.reallyExists(name); err != nil || exists {
+			return wrapErrorPath(name, err)
+		}
+		fsNode := node.parentWithFs()
+		if fsNode == nil {
+			return &os.PathError{Err: os.ErrNotExist, Op: "Mkdir", Path: name}
+		}
+		rel, err := filepath.Rel(fsNode.fullName(), name)
+		if err != nil {
+			return wrapErrorPath(name, err)
+		}
+		rel = string(filepath.Separator) + rel
+		if err := fsNode.fs.Mkdir(rel, perm); err != nil {
+			return wrapErrorPath(name, err)
+		}
+		return nil
+
+	} else {
+		fs, _, rel := m.node.findPath(name)
+		err := wrapErrorPath(name, fs.Mkdir(rel, perm))
+		return err
+	}
+}
+
+func (m *MountableFs) MkdirAll(path string, perm os.FileMode) error {
+	parts := splitPath(path)
+	partlen := len(parts)
+	for i := 0; i <= partlen; i++ {
+		cur := joinPath(parts[0:i])
+		if err := m.Mkdir(cur, perm); err != nil && !os.IsExist(err) {
+			return err
+		}
+	}
+	return nil
+}
+
+func (m *MountableFs) Create(name string) (File, error) {
+	return m.OpenFile(name, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0666)
+}
+
+func (m *MountableFs) Open(name string) (File, error) {
+	return m.OpenFile(name, os.O_RDONLY, 0)
+}
+
+func (m *MountableFs) OpenFile(name string, flag int, perm os.FileMode) (File, error) {
+	fs, _, rel := m.node.findPath(name)
+
+	exists := true
+	isdir, err := IsDir(fs, rel)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return nil, wrapErrorPath(name, err)
+		} else {
+			exists = false
+		}
+	}
+
+	if isdir || !exists {
+		node := m.node.findNode(name)
+		if node != nil {
+			file, err := fs.OpenFile(rel, flag, perm)
+			if err != nil && !os.IsNotExist(err) {
+				return nil, wrapErrorPath(name, err)
+			}
+			mf := &mountableFile{file: file, node: node, base: rel, name: node.name}
+			return mf, nil
+		}
+	}
+
+	// if we try to write a file into an intermediate node not backed by a
+	// directory, we should create it to preserve their illusion:
+	if flag&os.O_CREATE == os.O_CREATE {
+		parentName := filepath.Dir(name)
+		parent := m.node.findNode(parentName)
+
+		if parent != nil && parent.fs == nil {
+			parts := splitPath(parentName)
+			i := len(parts)
+
+			var fs Fs
+			next := parent
+			for next != nil && fs == nil {
+				if next.fs != nil {
+					fs = next.fs
+				}
+				if next.parent != nil {
+					i--
+				}
+				next = next.parent
+			}
+			for j := range parts[i:] {
+				if err := fs.Mkdir(joinPath(parts[i:i+j+1]), perm|0111); err != nil && !os.IsExist(err) {
+					return nil, wrapErrorPath(name, err)
+				}
+			}
+		}
+	}
+
+	return fs.OpenFile(rel, flag, perm)
+}
+
+func (m *MountableFs) Remove(name string) error {
+	fs, _, rel := m.node.findPath(name)
+	return wrapErrorPath(name, fs.Remove(rel))
+}
+
+func (m *MountableFs) RemoveAll(path string) error {
+	info, err := lstatIfOs(m, path)
+	if err != nil {
+		return wrapErrorPath(path, err)
+	}
+	err = departWalk(m, path, info, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if IsMountNode(info) {
+			return nil
+		} else {
+			if info.IsDir() {
+				node := m.node.findNode(path)
+				if node != nil {
+					return nil
+				}
+			}
+			return m.Remove(path)
+		}
+	})
+	return wrapErrorPath(path, err)
+}
+
+func (m *MountableFs) Rename(oldname string, newname string) error {
+	ofs, _, orel := m.node.findPath(oldname)
+	nfs, _, nrel := m.node.findPath(newname)
+
+	if ofs == nfs {
+		return wrapErrorPath(oldname, ofs.Rename(orel, nrel))
+	} else {
+		return errCrossFsRename
+	}
+}
+
+func (m *MountableFs) Stat(name string) (os.FileInfo, error) {
+	node := m.node.findNode(name)
+	if node != nil && node != m.node {
+		return mountedDirFromNode(node)
+	}
+	fs, _, rel := m.node.findPath(name)
+	info, err := fs.Stat(rel)
+	if err != nil {
+		return nil, wrapErrorPath(name, err)
+	}
+	return info, nil
+}
+
+func (m *MountableFs) Name() string {
+	return "MountableFs"
+}
+
+func (m *MountableFs) Chmod(name string, mode os.FileMode) error {
+	fs, _, rel := m.node.findPath(name)
+	return wrapErrorPath(name, fs.Chmod(rel, mode))
+}
+
+func (m *MountableFs) Chtimes(name string, atime time.Time, mtime time.Time) error {
+	fs, _, rel := m.node.findPath(name)
+	ok, err := Exists(fs, rel)
+	if err != nil {
+		return wrapErrorPath(name, err)
+	}
+	if !ok {
+		node := m.node.findNode(name)
+		if node == nil {
+			return &os.PathError{Err: os.ErrNotExist, Op: "Chtimes", Path: name}
+		}
+		node.modTime = mtime
+		return nil
+	} else {
+		return wrapErrorPath(name, fs.Chtimes(rel, atime, mtime))
+	}
+}
+
+// reallyExists returns true if the file or directory exists on the
+// base fs or any of the mounted fs, but not if the path is an intermediate
+// mounted node (i.e. if you mount a path but the in-between directories don't
+// exist).
+func (m *MountableFs) reallyExists(name string) (bool, error) {
+	s, err := m.Stat(name)
+	if os.IsNotExist(err) {
+		return false, nil
+	} else if err != nil {
+		return false, err
+	} else if IsMountNode(s) {
+		return false, nil
+	}
+	return true, nil
+}
+
+func wrapErrorPath(path string, err error) error {
+	if err == nil {
+		return nil
+	}
+	switch err := err.(type) {
+	case *os.PathError:
+		err.Path = path
+	default:
+		err = &os.PathError{Err: err, Path: path}
+	}
+	return err
+}
+
+type mountableNode struct {
+	fs           Fs
+	parent       *mountableNode
+	nodes        map[string]*mountableNode
+	name         string
+	mountedNodes int
+	modTime      time.Time
+	depth        int
+}
+
+func (n *mountableNode) parentWithFs() (node *mountableNode) {
+	node = n.parent
+	for node != nil {
+		if node.fs != nil {
+			return
+		}
+		node = node.parent
+	}
+	return
+}
+
+func (n *mountableNode) fullName() string {
+	out := []string{}
+	cur := n
+	for cur != nil {
+		if cur.name != "" {
+			out = append([]string{cur.name}, out...)
+		}
+		cur = cur.parent
+	}
+	return joinPath(out)
+}
+
+func (n *mountableNode) findNode(path string) *mountableNode {
+	parts := splitPath(path)
+	cur := n
+	for _, p := range parts {
+		if next, ok := cur.nodes[p]; ok && next != nil {
+			cur = next
+		} else {
+			return nil
+		}
+	}
+	return cur
+}
+
+func (n *mountableNode) findPath(path string) (fs Fs, base, rel string) {
+	parts := splitPath(path)
+
+	var out Fs
+	outIdx := -1
+	out = n.fs
+	cur := n
+	for i, p := range parts {
+		if next, ok := cur.nodes[p]; ok {
+			cur = next
+			if cur.fs != nil {
+				out = cur.fs
+				outIdx = i
+			}
+		} else {
+			break
+		}
+	}
+
+	// afero is a bit fussy and unpredictable about leading slashes.
+	return out,
+		string(filepath.Separator) + filepath.Join(parts[:outIdx+1]...),
+		string(filepath.Separator) + filepath.Join(parts[outIdx+1:]...)
+}
+
+type mountableFile struct {
+	name string
+	file File
+	node *mountableNode
+	base string
+}
+
+func (m *mountableFile) Readdir(count int) (out []os.FileInfo, err error) {
+	if m.file != nil {
+		out, err = m.file.Readdir(count)
+		if err != nil {
+			return
+		}
+	}
+	if m.node != nil {
+		for _, node := range m.node.nodes {
+			var mdi *mountedDirInfo
+			mdi, err = mountedDirFromNode(node)
+			if err != nil {
+				return
+			}
+			out = append(out, mdi)
+		}
+	}
+	return
+}
+
+func (m *mountableFile) Readdirnames(n int) (out []string, err error) {
+	if m.file != nil {
+		out, err = m.file.Readdirnames(n)
+		if err != nil {
+			return
+		}
+	}
+	if m.node != nil {
+		for part := range m.node.nodes {
+			out = append(out, part)
+		}
+	}
+	return
+}
+
+func (m *mountableFile) Close() error {
+	if m.file != nil {
+		return m.file.Close()
+	}
+	return nil
+}
+
+func (m *mountableFile) Read(p []byte) (n int, err error) {
+	if m.file != nil {
+		return m.file.Read(p)
+	}
+	return 0, errNotAFile
+}
+
+func (m *mountableFile) ReadAt(p []byte, off int64) (n int, err error) {
+	if m.file != nil {
+		return m.file.ReadAt(p, off)
+	}
+	return 0, errNotAFile
+}
+
+func (m *mountableFile) Seek(offset int64, whence int) (int64, error) {
+	if m.file != nil {
+		return m.file.Seek(offset, whence)
+	}
+	return 0, errNotAFile
+}
+
+func (m *mountableFile) Write(p []byte) (n int, err error) {
+	if m.file != nil {
+		return m.file.Write(p)
+	}
+	return 0, errNotAFile
+}
+
+func (m *mountableFile) WriteAt(p []byte, off int64) (n int, err error) {
+	if m.file != nil {
+		return m.file.WriteAt(p, off)
+	}
+	return 0, errNotAFile
+}
+
+func (m *mountableFile) Name() string { return m.name }
+
+func (m *mountableFile) Stat() (os.FileInfo, error) {
+	if m.file != nil {
+		return m.file.Stat()
+	} else {
+		if m.node != nil {
+			mdi, err := mountedDirFromNode(m.node)
+			if err != nil {
+				return nil, err
+			}
+			return mdi, nil
+		}
+	}
+	return nil, os.ErrNotExist
+}
+
+func (m *mountableFile) Sync() error {
+	if m.file != nil {
+		return m.file.Sync()
+	}
+	return errNotAFile
+}
+
+func (m *mountableFile) Truncate(size int64) error {
+	if m.file != nil {
+		return m.file.Truncate(size)
+	}
+	return errNotAFile
+}
+
+func (m *mountableFile) WriteString(s string) (ret int, err error) {
+	if m.file != nil {
+		return m.file.WriteString(s)
+	}
+	return 0, errNotAFile
+}
+
+type mountedDirInfo struct {
+	name    string
+	mode    os.FileMode
+	modTime time.Time
+}
+
+func (m *mountedDirInfo) Name() string       { return m.name }
+func (m *mountedDirInfo) Mode() os.FileMode  { return m.mode | os.ModeDir }
+func (m *mountedDirInfo) ModTime() time.Time { return m.modTime }
+func (m *mountedDirInfo) IsDir() bool        { return true }
+func (m *mountedDirInfo) Sys() interface{}   { return nil }
+
+func (m *mountedDirInfo) Size() int64 {
+	// copied from afero, not sure why it's 42.
+	return int64(42)
+}
+
+func mountedDirFromNode(node *mountableNode) (*mountedDirInfo, error) {
+	if node.name == "" {
+		panic("missing name from node")
+	}
+	mdi := &mountedDirInfo{
+		name:    node.name,
+		mode:    0777,
+		modTime: node.modTime,
+	}
+	if node.fs != nil {
+		// dir should inherit stat info of mounted fs root node
+		info, err := node.fs.Stat("/")
+		if err != nil {
+			return nil, err
+		}
+		mdi.modTime = info.ModTime()
+		mdi.mode = info.Mode()
+	}
+	return mdi, nil
+}
+
+var (
+	errCrossFsRename  = errors.New("cross-fs rename")
+	errRecursiveMount = errors.New("recursive mount")
+	errShortCopy      = errors.New("short copy")
+	errAlreadyMounted = errors.New("already mounted")
+	errNotMounted     = errors.New("not mounted")
+	errNotAFile       = errors.New("not a file")
+	errOsFs           = errors.New("afero.OsFs should not be mounted - use afero.BasePathFs instead")
+)
+
+func underlyingError(err error) error {
+	switch err := err.(type) {
+	case *os.PathError:
+		return err.Err
+	}
+	return err
+}
+
+func IsErrCrossFsRename(err error) bool  { return underlyingError(err) == errCrossFsRename }
+func IsErrRecursiveMount(err error) bool { return underlyingError(err) == errRecursiveMount }
+func IsErrShortCopy(err error) bool      { return underlyingError(err) == errShortCopy }
+func IsErrAlreadyMounted(err error) bool { return underlyingError(err) == errAlreadyMounted }
+func IsErrNotMounted(err error) bool     { return underlyingError(err) == errNotMounted }
+func IsErrNotAFile(err error) bool       { return underlyingError(err) == errNotAFile }
+func IsErrOsFs(err error) bool           { return underlyingError(err) == errOsFs }
+
+func splitPath(path string) []string {
+	in := strings.Trim(path, string(filepath.Separator))
+	if in == "" {
+		return nil
+	}
+	return strings.Split(in, string(filepath.Separator))
+}
+
+func joinPath(parts []string) string {
+	return string(filepath.Separator) + strings.Join(parts, string(filepath.Separator))
+}
+
+func IsMountNode(info os.FileInfo) bool {
+	if _, ok := info.(*mountedDirInfo); ok {
+		return true
+	}
+	return false
+}
+
+// departWalk recursively descends path, calling walkFn.
+// it calls walkFn on departure rather than arrival, allowing removal
+// adapted from afero.walk
+func departWalk(fs Fs, path string, info os.FileInfo, walkFn filepath.WalkFunc) error {
+	if info.IsDir() {
+		names, err := readDirNames(fs, path)
+		if err != nil {
+			return walkFn(path, info, err)
+		}
+
+		for _, name := range names {
+			filename := filepath.Join(path, name)
+			fileInfo, err := lstatIfOs(fs, filename)
+			if err != nil {
+				if err := walkFn(filename, fileInfo, err); err != nil {
+					return err
+				}
+			} else {
+				err = departWalk(fs, filename, fileInfo, walkFn)
+				if err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return walkFn(path, info, nil)
+}

--- a/mountfs_test.go
+++ b/mountfs_test.go
@@ -1,3 +1,16 @@
+// Copyright © 2017 Blake Williams <code@shabbyrobe.org>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package afero
 
 import (

--- a/mountfs_test.go
+++ b/mountfs_test.go
@@ -1,0 +1,805 @@
+package afero
+
+import (
+	"fmt"
+	gorand "math/rand"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+)
+
+// FIXME: not properly cleaning up temp
+
+func must(t *testing.T, errs ...error) {
+	// FIXME: afero may not accept Go 1.9 features
+	t.Helper()
+	for _, err := range errs {
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func TestMountableFsChild(t *testing.T) {
+	base := NewMemMapFs()
+	mfs := NewMountableFs(base)
+
+	child1 := NewMemMapFs()
+	must(t,
+		mfs.Mount("test", child1),
+		WriteFile(mfs, "/foo", []byte("1"), 0644),
+		WriteFile(mfs, "/test/bar", []byte("2"), 0644))
+
+	if err := checkPaths([]string{"/", "/foo"}, base); err != nil {
+		t.Fatal(err)
+	}
+	if err := checkPaths([]string{"/", "/bar"}, child1); err != nil {
+		t.Fatal(err)
+	}
+	if err := checkPaths([]string{"/", "/foo", "/test", "/test/bar"}, mfs); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestMountableFsNestedChild(t *testing.T) {
+	base := NewMemMapFs()
+	mfs := NewMountableFs(base)
+
+	child := NewMemMapFs()
+	must(t,
+		mfs.Mount("test/a/b", child),
+		WriteFile(mfs, "/foo", []byte("1"), 0644),
+		WriteFile(mfs, "/test/a/b/baz", []byte("3"), 0644))
+
+	if err := checkPaths([]string{"/", "/foo"}, base); err != nil {
+		t.Fatal(err)
+	}
+	if err := checkPaths([]string{"/", "/baz"}, child); err != nil {
+		t.Fatal(err)
+	}
+	if err := checkPaths([]string{"/", "/foo", "/test", "/test/a", "/test/a/b", "/test/a/b/baz"}, mfs); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestMountableFsSameFsMultipleMounts(t *testing.T) {
+	mfs := NewMountableFs(nil)
+	child := NewMemMapFs()
+	must(t,
+		mfs.Mount("/foo", child),
+		mfs.Mount("/bar", child),
+		WriteFile(mfs, "/child/test", []byte("1"), 0644),
+	)
+
+	if err := WriteFile(mfs, "/foo/test", []byte("1"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if exists, err := Exists(mfs, "/foo/test"); err != nil || !exists {
+		t.Fatal(err, exists)
+	}
+	if exists, err := Exists(mfs, "/bar/test"); err != nil || !exists {
+		t.Fatal(err, exists)
+	}
+}
+
+func TestMountableFsRecursive(t *testing.T) {
+	{ // recursive mount should fail
+		mfs := NewMountableFs(nil)
+		child := NewMemMapFs()
+		must(t, mfs.Mount("/child", child))
+		if err := mfs.Mount("/child/nested", child); !IsErrRecursiveMount(err) {
+			t.Fatal(err)
+		}
+	}
+	{ // recursive mount allowed
+		mfs := NewMountableFs(nil)
+		mfs.AllowRecursiveMount = true
+		child := NewMemMapFs()
+		must(t, mfs.Mount("/child", child),
+			mfs.Mount("/child/nested", child),
+			WriteFile(mfs, "/child/foo", []byte("1"), 0644),
+		)
+		if err := WriteFile(mfs, "/child/nested/foo", []byte("1"), 0644); err != nil {
+			t.Fatal(err)
+		}
+		if exists, err := Exists(mfs, "/child/foo"); err != nil || !exists {
+			t.Fatal(err, exists)
+		}
+		if exists, err := Exists(mfs, "/child/nested/foo"); err != nil || !exists {
+			t.Fatal(err, exists)
+		}
+	}
+}
+
+func TestMountableFsNestedChildInsideAnotherMount(t *testing.T) {
+	base := NewMemMapFs()
+	mfs := NewMountableFs(base)
+
+	child1 := NewMemMapFs()
+	child2 := NewMemMapFs()
+	must(t,
+		mfs.Mount("test", child1),
+		mfs.Mount("test/a/b", child2),
+		WriteFile(mfs, "/foo", []byte("1"), 0644),
+		WriteFile(mfs, "/test/bar", []byte("2"), 0644),
+		WriteFile(mfs, "/test/a/b/baz", []byte("3"), 0644),
+	)
+
+	if err := checkPaths([]string{"/", "/foo"}, base); err != nil {
+		t.Fatal(err)
+	}
+	if err := checkPaths([]string{"/", "/bar"}, child1); err != nil {
+		t.Fatal(err)
+	}
+	if err := checkPaths([]string{"/", "/baz"}, child2); err != nil {
+		t.Fatal(err)
+	}
+	if err := checkPaths([]string{"/", "/foo", "/test", "/test/a", "/test/a/b", "/test/a/b/baz", "/test/bar"}, mfs); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestMountableFsUnmountFsMountedBetweenMounts(t *testing.T) {
+	base := NewMemMapFs()
+	mfs := NewMountableFs(base)
+
+	must(t,
+		mfs.Mount("test", NewMemMapFs()),
+		mfs.Mount("test/foo", NewMemMapFs()),
+		mfs.Mount("test/foo/bar", NewMemMapFs()),
+		mfs.Mount("test/bar", NewMemMapFs()),
+
+		WriteFile(mfs, "/test/a", []byte("1"), 0644),
+		WriteFile(mfs, "/test/foo/a", []byte("2"), 0644),
+		WriteFile(mfs, "/test/foo/bar/a", []byte("3"), 0644),
+		WriteFile(mfs, "/test/bar/a", []byte("4"), 0644),
+	)
+
+	if err := checkPaths([]string{"/", "/test", "/test/a", "/test/foo", "/test/foo/a", "/test/foo/bar", "/test/foo/bar/a", "/test/bar", "/test/bar/a"}, mfs); err != nil {
+		t.Fatal(err)
+	}
+	must(t, mfs.Umount("test"))
+	if err := checkPaths([]string{"/", "/test", "/test/foo", "/test/foo/a", "/test/foo/bar", "/test/foo/bar/a", "/test/bar", "/test/bar/a"}, mfs); err != nil {
+		t.Fatal(err)
+	}
+	must(t, mfs.Umount("test/foo"))
+	if err := checkPaths([]string{"/", "/test", "/test/foo", "/test/foo/bar", "/test/foo/bar/a", "/test/bar", "/test/bar/a"}, mfs); err != nil {
+		t.Fatal(err)
+	}
+	must(t, mfs.Umount("test/bar"))
+	if err := checkPaths([]string{"/", "/test", "/test/foo", "/test/foo/bar", "/test/foo/bar/a"}, mfs); err != nil {
+		t.Fatal(err)
+	}
+	must(t, mfs.Umount("test/foo/bar"))
+	if err := checkPaths([]string{"/"}, mfs); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestMountableFsWriteFileOverNodeShouldFail(t *testing.T) {
+	base := NewMemMapFs()
+
+	mfs := NewMountableFs(base)
+	must(t, mfs.Mount("test", NewMemMapFs()))
+	if err := WriteFile(mfs, "/test", []byte("1"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Intermediate nodes should fail too
+	mfs = NewMountableFs(base)
+	must(t, mfs.Mount("test/test", NewMemMapFs()))
+	if err := WriteFile(mfs, "/test", []byte("1"), 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestMountableFsMountErrors(t *testing.T) {
+	{ // Can not mount over an existing mount
+		base := NewMemMapFs()
+		mfs := NewMountableFs(base)
+		if err := mfs.Mount("test", NewMemMapFs()); err != nil {
+			t.Fatal(err)
+		}
+		if err := mfs.Mount("test", NewMemMapFs()); !IsErrAlreadyMounted(err) {
+			t.Fatal(err)
+		}
+	}
+
+	{ // Can not mount over an existing dir
+		base := NewMemMapFs()
+		mfs := NewMountableFs(base)
+		if err := mfs.Mkdir("test", 0777); err != nil {
+			t.Fatal(err)
+		}
+		if err := mfs.Mount("test", NewMemMapFs()); !os.IsExist(err) {
+			t.Fatal(err)
+		}
+	}
+
+	{ // Can not mount over an existing file
+		base := NewMemMapFs()
+		mfs := NewMountableFs(base)
+		if err := WriteFile(mfs, "test", []byte("1"), 0777); err != nil {
+			t.Fatal(err)
+		}
+		if err := mfs.Mount("test", NewMemMapFs()); !os.IsExist(err) {
+			t.Fatal(err)
+		}
+	}
+}
+
+func TestMountableFsMountOverIntermediateNode(t *testing.T) {
+	base := NewMemMapFs()
+	mfs := NewMountableFs(base)
+
+	child1 := NewMemMapFs()
+	if err := mfs.Mount("test/a/b", child1); err != nil {
+		t.Fatal(err)
+	}
+
+	// intermediate node "test" already exists, but has no fs attached yet
+	// so this should still work.
+	child2 := NewMemMapFs()
+	if err := mfs.Mount("test", child2); err != nil {
+		t.Fatal(err)
+	}
+
+	must(t,
+		WriteFile(mfs, "/foo", []byte("1"), 0644),
+		WriteFile(mfs, "/test/a/b/baz", []byte("3"), 0644))
+
+	if err := checkPaths([]string{"/", "/foo"}, base); err != nil {
+		t.Fatal(err)
+	}
+	if err := checkPaths([]string{"/", "/baz"}, child1); err != nil {
+		t.Fatal(err)
+	}
+	if err := checkPaths([]string{"/", "/foo", "/test", "/test/a", "/test/a/b", "/test/a/b/baz"}, mfs); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestMountableFsWriteIntoIntermediateNode(t *testing.T) {
+	var end []func()
+	defer func() {
+		for _, f := range end {
+			f()
+		}
+	}()
+	var bases = []func() Fs{
+		func() Fs { return NewMemMapFs() },
+		func() Fs {
+			tfs := newTempFs()
+			end = append(end, func() { tfs.Destroy() })
+			return tfs
+		},
+	}
+
+	for idx, base := range bases {
+		t.Run(fmt.Sprintf("%d", idx), func(t *testing.T) {
+			{ // intermediate nodes are created:
+				base := base()
+				mfs := NewMountableFs(base)
+				child1 := NewMemMapFs()
+				must(t, mfs.Mount("/test/a/b", child1))
+				if exists, _ := Exists(base, "/test/a"); exists {
+					t.Fatal()
+				}
+				must(t, WriteFile(mfs, "/test/a/yep", []byte("1"), 0755))
+				mustStatRealDir(t, base, "/test", 0755)
+				mustStatRealDir(t, base, "/test/a", 0755)
+			}
+
+			{ // intermediate child of real dir is created:
+				base := base()
+				mfs := NewMountableFs(base)
+				child1 := NewMemMapFs()
+				must(t, mfs.Mkdir("/test", 0755))
+				must(t, mfs.Mount("/test/a/b", child1))
+				if exists, _ := Exists(base, "/test"); !exists {
+					t.Fatal()
+				}
+				if exists, _ := Exists(base, "/test/a"); exists {
+					t.Fatal()
+				}
+				must(t, WriteFile(mfs, "/test/a/yep", []byte("1"), 0755))
+				mustStatRealDir(t, base, "/test/a", 0755)
+			}
+		})
+	}
+}
+
+func TestMountableFsReadDir(t *testing.T) {
+	base := NewMemMapFs()
+
+	now := time.Now()
+	child := NewMemMapFs()
+	must(t,
+		child.Chmod("/", 0777),
+		child.Chtimes("/", now, now))
+
+	mfs := NewMountableFs(base)
+	must(t, mfs.Mount("test/test", child))
+
+	{
+		read1, err := ReadDir(mfs, "/")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(read1) != 1 {
+			t.Fatal()
+		}
+		if read1[0].Name() != "test" {
+			t.Fatal()
+		}
+		if read1[0].Mode() != 0777|os.ModeDir {
+			t.Fatal()
+		}
+		if read1[0].ModTime().IsZero() {
+			t.Fatal()
+		}
+	}
+
+	{
+		read2, err := ReadDir(mfs, "/test")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(read2) != 1 {
+			t.Fatal()
+		}
+		if read2[0].Name() != "test" {
+			t.Fatal()
+		}
+		if read2[0].Mode() != 0777|os.ModeDir {
+			t.Fatal()
+		}
+		if read2[0].ModTime() != now {
+			t.Fatal()
+		}
+	}
+}
+
+func TestMountableFsRename(t *testing.T) {
+	base := NewMemMapFs()
+	mfs := NewMountableFs(base)
+
+	input := []byte("1")
+	if err := WriteFile(mfs, "/test/foo", input, 0644); err != nil {
+		t.Fatal(err)
+	}
+	err := mfs.Rename("/test/foo", "/bar")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = ReadFile(mfs, "/test/foo")
+	if !os.IsNotExist(err) {
+		t.Fatal(err)
+	}
+	result, err := ReadFile(mfs, "/bar")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(result, input) {
+		t.Fatal()
+	}
+}
+
+func TestMountableFsCrossFsRename(t *testing.T) {
+	base := NewMemMapFs()
+	mfs := NewMountableFs(base)
+
+	child := NewMemMapFs()
+	if err := mfs.Mount("test", child); err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteFile(mfs, "/test/foo", []byte("1"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	err := mfs.Rename("/test/foo", "/bar")
+	if err != errCrossFsRename {
+		t.Fatal(err)
+	}
+}
+
+func TestMountableFsMemMapFsOverOsFs(t *testing.T) {
+	tfs := newTempFs()
+	defer tfs.Destroy()
+
+	mfs := NewMountableFs(tfs)
+	child := NewMemMapFs()
+	if err := mfs.Mount("/child", child); err != nil {
+		t.Fatal(err)
+	}
+	in := []byte("1")
+	if err := WriteFile(mfs, "/child/foo", in, 0644); err != nil {
+		t.Fatal(err)
+	}
+	out, err := ReadFile(child, "/foo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(in, out) {
+		t.Fatal()
+	}
+
+	out, err = ReadFile(mfs, "/child/foo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(in, out) {
+		t.Fatal()
+	}
+}
+
+func TestMountableFsRemove(t *testing.T) {
+	mfs := NewMountableFs(nil)
+	child := NewMemMapFs()
+	if err := mfs.Mount("/child", child); err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteFile(mfs, "/child/test", []byte("1"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if e, err := Exists(mfs, "/child/test"); !e || err != nil {
+		t.Fatal(e, err)
+	}
+	if err := mfs.Remove("/child/test"); err != nil {
+		t.Fatal(err)
+	}
+	if e, err := Exists(mfs, "/child/test"); e || err != nil {
+		t.Fatal(e, err)
+	}
+}
+
+func TestMountableFsRemoveAll(t *testing.T) {
+	mfs := NewMountableFs(nil)
+	child1 := NewMemMapFs()
+	child2 := NewMemMapFs()
+	must(t,
+		mfs.Mount("/mntchild", child1),
+		mfs.Mount("/mntchild/nested", child2),
+		WriteFile(mfs, "/test", []byte("1"), 0644),
+		WriteFile(mfs, "/child/test", []byte("1"), 0644),
+		WriteFile(mfs, "/mntchild/foo", []byte("1"), 0644),
+		WriteFile(mfs, "/mntchild/bar", []byte("1"), 0644),
+		WriteFile(mfs, "/mntchild/baz/qux", []byte("1"), 0644),
+		WriteFile(mfs, "/mntchild/nested/a", []byte("1"), 0644),
+		WriteFile(mfs, "/mntchild/nested/b/c", []byte("1"), 0644),
+	)
+	if err := mfs.RemoveAll("/"); err != nil {
+		t.Fatal(err)
+	}
+	paths := []string{}
+	err := Walk(mfs, "/", func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		paths = append(paths, path)
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual([]string{"/", "/mntchild", "/mntchild/nested"}, paths) {
+		t.Fatal(paths)
+	}
+}
+
+func TestMountableFsRemoveAllRecursiveMount(t *testing.T) {
+	mfs := NewMountableFs(nil)
+	mfs.AllowRecursiveMount = true
+	child1 := NewMemMapFs()
+	must(t,
+		mfs.Mount("/mntchild", child1),
+		mfs.Mount("/mntchild/nested", child1),
+		WriteFile(mfs, "/mntchild/foo", []byte("1"), 0644),
+		WriteFile(mfs, "/mntchild/nested/bar", []byte("1"), 0644),
+	)
+	if err := mfs.RemoveAll("/"); err != nil {
+		t.Fatal(err)
+	}
+	paths := []string{}
+	err := Walk(mfs, "/", collectPaths(&paths))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual([]string{"/", "/mntchild", "/mntchild/nested"}, paths) {
+		t.Fatal(paths)
+	}
+}
+
+func TestMountableFsStat(t *testing.T) {
+	base := NewMemMapFs()
+	mfs := NewMountableFs(base)
+	child := NewMemMapFs()
+	child2 := NewMemMapFs()
+	must(t,
+		mfs.Mount("/child", child),
+		mfs.Mount("/child/nested", child2),
+		WriteFile(mfs, "/child/foo", []byte("1"), 0644),
+		WriteFile(mfs, "/child/nested/baz", []byte("1"), 0644))
+
+	if i, err := mfs.Stat("/child/foo"); err != nil {
+		t.Fatal(err)
+	} else {
+		if i.Name() != "foo" || i.IsDir() {
+			t.Fatal()
+		}
+	}
+	if i, err := mfs.Stat("/child/nested/baz"); err != nil {
+		t.Fatal(err)
+	} else {
+		if i.Name() != "baz" || i.IsDir() {
+			t.Fatal()
+		}
+	}
+	if i, err := mfs.Stat("/child/nested"); err != nil {
+		t.Fatal(err)
+	} else {
+		if i.Name() != "nested" || !i.IsDir() {
+			t.Fatal()
+		}
+	}
+	if i, err := mfs.Stat("/"); err != nil {
+		t.Fatal(err)
+	} else {
+		if i.Name() != "" || !i.IsDir() {
+			t.Fatal()
+		}
+	}
+}
+
+func TestMountableFsMkdirAll(t *testing.T) {
+	base := NewMemMapFs()
+	mfs := NewMountableFs(base)
+	child1 := NewMemMapFs()
+	child1.Chmod("/", 0777)
+	child2 := NewMemMapFs()
+	child2.Chmod("/", 0777)
+
+	must(t,
+		mfs.Mount("/child", child1),
+		mfs.Mount("/child/deeply/nested", child2))
+
+	if err := mfs.MkdirAll("/child/deeply/nested/dir", 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	mustStatLooseDir(t, mfs, "/child", 0777|os.ModeDir)
+	mustStatLooseDir(t, mfs, "/child/deeply", 0777|os.ModeDir)
+	mustStatLooseDir(t, mfs, "/child/deeply/nested", 0777|os.ModeDir)
+	mustStatLooseDir(t, mfs, "/child/deeply/nested/dir", 0755|os.ModeDir)
+
+	// directories should be created under the mounts
+	mustStatLooseDir(t, base, "/child", 0755|os.ModeDir)
+	mustStatLooseDir(t, child1, "/deeply", 0755|os.ModeDir)
+	mustStatLooseDir(t, child1, "/deeply/nested", 0755|os.ModeDir)
+}
+
+func TestMountableFsChmod(t *testing.T) {
+	mfs := NewMountableFs(nil)
+	child1 := NewMemMapFs()
+	child2 := NewMemMapFs()
+	must(t,
+		mfs.Mount("/child", child1),
+
+		// Ensure there is an intermediate node
+		mfs.Mount("/child/deeply/nested", child2),
+
+		WriteFile(mfs, "/child/foo", []byte("1"), 0644),
+		mfs.Mkdir("/child/dir", 0755))
+
+	// sanity checks - make sure the initial state matches this test's expectation
+	mustStatLooseDir(t, mfs, "/child", os.ModeDir)
+	mustStat(t, mfs, "/child/foo", 0644)
+	mustStatLooseDir(t, mfs, "/child/dir", 0755|os.ModeDir)
+	mustStatLooseDir(t, mfs, "/child/deeply", 0777|os.ModeDir)
+	mustStatLooseDir(t, mfs, "/child/deeply/nested", os.ModeDir)
+
+	if err := mfs.Chmod("/child", 0777|os.ModeDir); err != nil {
+		t.Fatal(err)
+	}
+	if err := mfs.Chmod("/child/foo", 0777); err != nil {
+		t.Fatal(err)
+	}
+
+	// This seems weird about MemMapFs - it will return os.ModeDir if you call
+	// Mkdir, but it allows you to Chmod this flag away even though the entry
+	// remains a directory.
+	if err := mfs.Chmod("/child/dir", 0777|os.ModeDir); err != nil {
+		t.Fatal(err)
+	}
+
+	mustStatLooseDir(t, mfs, "/child", 0777)
+	mustStat(t, mfs, "/child/foo", 0777)
+	mustStatLooseDir(t, mfs, "/child/dir", 0777)
+}
+
+func TestMountableFsChtimes(t *testing.T) {
+	mfs := NewMountableFs(nil)
+	child := NewMemMapFs()
+	must(t,
+		mfs.Mount("/child", child),
+		WriteFile(mfs, "/child/foo", []byte("1"), 0644),
+		mfs.Mkdir("/child/dir", 0755))
+
+	tm := time.Date(2017, 1, 1, 12, 0, 0, 0, time.UTC)
+
+	must(t,
+		mfs.Chtimes("/child", time.Time{}, tm),
+		mfs.Chtimes("/child/foo", time.Time{}, tm),
+		mfs.Chtimes("/child/dir", time.Time{}, tm))
+
+	mustTime(t, mfs, "/child", tm)
+	mustTime(t, mfs, "/child/foo", tm)
+	mustTime(t, mfs, "/child/dir", tm)
+}
+
+func TestMountableFsPathErrors(t *testing.T) {
+	mfs := NewMountableFs(nil)
+	child := NewMemMapFs()
+	must(t, mfs.Mount("/nested/child", child))
+
+	expected := "/nested/child/dir/file"
+
+	funcs := []func() error{
+		func() error {
+			_, err := mfs.Stat(expected)
+			return err
+		},
+		func() error { return mfs.Chmod(expected, 0644) },
+		func() error { return mfs.Chtimes(expected, time.Time{}, time.Time{}) },
+		func() error { return mfs.Rename(expected, "/nested/child/flarg") },
+		func() error { return mfs.Remove(expected) },
+		func() error { return mfs.RemoveAll(expected) },
+
+		// MemMapFs creates intermediate dirs!
+		// func() error { return mfs.Mkdir(expected, 0777) },
+	}
+	for i, fn := range funcs {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			err := fn()
+			if err == nil {
+				t.Fatal()
+			}
+			perr, ok := err.(*os.PathError)
+			if !ok {
+				t.Fatal(err)
+			}
+			if perr.Path != expected {
+				t.Fatal(perr.Path, "!=", expected)
+			}
+			if perr.Err == nil || perr.Err != underlyingError(perr) {
+				t.Fatal()
+			}
+		})
+	}
+}
+
+func mustTime(t *testing.T, fs Fs, path string, tm time.Time) {
+	t.Helper()
+	if i, err := fs.Stat(path); err != nil {
+		t.Fatal(err)
+	} else {
+		if i.ModTime() != tm {
+			t.Fatal(i.ModTime(), "!=", tm)
+		}
+	}
+}
+
+func mustStatLooseDir(t *testing.T, fs Fs, dir string, mode os.FileMode) {
+	t.Helper()
+	mode |= os.ModeDir
+	if i, err := fs.Stat(dir); err != nil {
+		t.Fatal(err)
+	} else {
+		if i.Name() != filepath.Base(dir) {
+			t.Fatal(i.Name(), filepath.Base(dir))
+		} else if !i.IsDir() {
+			t.Fatal("not dir")
+		} else if i.Mode() != mode {
+			t.Fatal("mode mismatch", mode, i.Mode())
+		}
+	}
+}
+
+func mustStatRealDir(t *testing.T, fs Fs, dir string, mode os.FileMode) {
+	t.Helper()
+	mustStatLooseDir(t, fs, dir, mode)
+	i, _ := fs.Stat(dir)
+	_, ok := i.(*mountedDirInfo)
+	if ok {
+		t.Fatal()
+	}
+}
+
+func mustStatMount(t *testing.T, fs Fs, dir string, mode os.FileMode) {
+	t.Helper()
+	mustStatLooseDir(t, fs, dir, mode)
+	i, _ := fs.Stat(dir)
+	_, ok := i.(*mountedDirInfo)
+	if !ok {
+		t.Fatal()
+	}
+}
+
+func mustStat(t *testing.T, fs Fs, file string, mode os.FileMode) {
+	t.Helper()
+	if i, err := fs.Stat(file); err != nil {
+		t.Fatal(err)
+	} else {
+		if i.Name() != filepath.Base(file) {
+			t.Fatal(i.Name(), filepath.Base(file))
+		} else if i.IsDir() {
+			t.Fatal("not file")
+		} else if i.Mode() != mode {
+			t.Fatal("mode mismatch", mode, i.Mode())
+		}
+	}
+}
+
+func checkPaths(expected []string, fs Fs) error {
+	result := []string{}
+	if err := Walk(fs, "/", collectPaths(&result)); err != nil {
+		return err
+	}
+	sort.Strings(result)
+	sort.Strings(expected)
+	if !reflect.DeepEqual(expected, result) {
+		return fmt.Errorf("paths did not match.\nexpect: %v\nactual: %v", expected, result)
+	}
+	return nil
+}
+
+func collectPaths(into *[]string) filepath.WalkFunc {
+	return func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		*into = append(*into, path)
+		return nil
+	}
+}
+
+func printFile(path string, info os.FileInfo, err error) error {
+	if err != nil {
+		fmt.Println(err)
+	} else {
+		fmt.Println(path, info.Name())
+	}
+	return nil
+}
+
+var tempFsRandSource = gorand.NewSource(time.Now().UnixNano())
+
+type tempFs struct {
+	Fs
+	path string
+}
+
+func (t *tempFs) Destroy() {
+	if !strings.HasPrefix(t.path, os.TempDir()) {
+		panic("path did not start with temp dir")
+	}
+	if err := os.RemoveAll(t.path); err != nil {
+		panic(err)
+	}
+	if err := os.RemoveAll(t.path); err != nil {
+		panic(err)
+	}
+}
+
+func newTempFs() *tempFs {
+	p := fmt.Sprintf("%d.%d", time.Now().UnixNano(), tempFsRandSource.Int63())
+	td := filepath.Join(os.TempDir(), p)
+	if err := os.Mkdir(td, 0777); err != nil {
+		panic(err)
+	}
+	t := NewBasePathFs(NewOsFs(), td)
+	return &tempFs{Fs: t, path: td}
+}

--- a/mountfs_test.go
+++ b/mountfs_test.go
@@ -26,8 +26,8 @@ import (
 )
 
 func must(t *testing.T, errs ...error) {
-	// FIXME: afero may not accept Go 1.9 features
-	t.Helper()
+	// Re-enable when Go 1.9 is the minimum
+	// t.Helper()
 	for _, err := range errs {
 		if err != nil {
 			t.Fatal(err)
@@ -696,7 +696,8 @@ func TestMountableFsPathErrors(t *testing.T) {
 }
 
 func mustTime(t *testing.T, fs Fs, path string, tm time.Time) {
-	t.Helper()
+	// Re-enable when Go 1.9 is the minimum
+	// t.Helper()
 	path = filepath.FromSlash(path)
 	if i, err := fs.Stat(path); err != nil {
 		t.Fatal(err)
@@ -708,7 +709,8 @@ func mustTime(t *testing.T, fs Fs, path string, tm time.Time) {
 }
 
 func mustStatLooseDir(t *testing.T, fs Fs, dir string, mode os.FileMode) {
-	t.Helper()
+	// Re-enable when Go 1.9 is the minimum
+	// t.Helper()
 	dir = filepath.FromSlash(dir)
 	mode |= os.ModeDir
 	if i, err := fs.Stat(dir); err != nil {
@@ -725,7 +727,8 @@ func mustStatLooseDir(t *testing.T, fs Fs, dir string, mode os.FileMode) {
 }
 
 func mustStatRealDir(t *testing.T, fs Fs, dir string, mode os.FileMode) {
-	t.Helper()
+	// Re-enable when Go 1.9 is the minimum
+	// t.Helper()
 	dir = filepath.FromSlash(dir)
 	mustStatLooseDir(t, fs, dir, mode)
 	i, _ := fs.Stat(dir)
@@ -736,7 +739,8 @@ func mustStatRealDir(t *testing.T, fs Fs, dir string, mode os.FileMode) {
 }
 
 func mustStatMount(t *testing.T, fs Fs, dir string, mode os.FileMode) {
-	t.Helper()
+	// Re-enable when Go 1.9 is the minimum
+	// t.Helper()
 	dir = filepath.FromSlash(dir)
 	mustStatLooseDir(t, fs, dir, mode)
 	i, _ := fs.Stat(dir)
@@ -747,7 +751,8 @@ func mustStatMount(t *testing.T, fs Fs, dir string, mode os.FileMode) {
 }
 
 func mustStat(t *testing.T, fs Fs, file string, mode os.FileMode) {
-	t.Helper()
+	// Re-enable when Go 1.9 is the minimum
+	// t.Helper()
 	file = filepath.FromSlash(file)
 	if i, err := fs.Stat(file); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Here's a feature that we are using on my current project - a mountable file system, similar to unix bind mounts. I thought I should polish it up and submit it back in case others find it useful.

Basic usage:

```go
base := afero.NewBasePathFs(afero.NewOsFs(), "/tmp")
fs := afero.NewMountableFs(base)

child := afero.NewMemMapFs()
_ = fs.Mount("/child", child)

in := []byte("1")
afero.WriteFile(fs, "/child/test", in, 0644)
out, _ := afero.ReadFile(child, "/test")

// should print true
fmt.Println(bytes.Equal(in, out))
```

Currently the tests have it nearly 80% covered. I thought I'd hold off polishing it any further in case there was feedback that needed to be addressed.

I had a few questions about how best to organise things - I notice that some filesystems are in the root `afero` package, but others have their own subpackages. This exports a fair few types, should I move it into a package of its own?

I have written a few tests against OsFs which make use of a temp directory which is destroyed in a defer. I've tried to write as few tests as possible in that way as I wasn't sure if this was ok to do but some of them really benefited from hitting the OsFs implementation as well.