### PR TITLE
fix File.Name() on BasePathFS (wrap File objects returned by BasePathFs)

### DIFF
--- a/basepath.go
+++ b/basepath.go
@@ -22,6 +22,16 @@ type BasePathFs struct {
 	path   string
 }
 
+type BasePathFile struct {
+	File
+	path string
+}
+
+func (f *BasePathFile) Name() string {
+	sourcename := f.File.Name()
+	return strings.TrimPrefix(sourcename, f.path)
+}
+
 func NewBasePathFs(source Fs, path string) Fs {
 	return &BasePathFs{source: source, path: path}
 }
@@ -111,14 +121,22 @@ func (b *BasePathFs) OpenFile(name string, flag int, mode os.FileMode) (f File, 
 	if name, err = b.RealPath(name); err != nil {
 		return nil, &os.PathError{Op: "openfile", Path: name, Err: err}
 	}
-	return b.source.OpenFile(name, flag, mode)
+	sourcef, err := b.source.OpenFile(name, flag, mode)
+	if err != nil {
+		return nil, err
+	}
+	return &BasePathFile{sourcef, b.path}, nil
 }
 
 func (b *BasePathFs) Open(name string) (f File, err error) {
 	if name, err = b.RealPath(name); err != nil {
 		return nil, &os.PathError{Op: "open", Path: name, Err: err}
 	}
-	return b.source.Open(name)
+	sourcef, err := b.source.Open(name)
+	if err != nil {
+		return nil, err
+	}
+	return &BasePathFile{File: sourcef, path: b.path}, nil
 }
 
 func (b *BasePathFs) Mkdir(name string, mode os.FileMode) (err error) {
@@ -139,7 +157,11 @@ func (b *BasePathFs) Create(name string) (f File, err error) {
 	if name, err = b.RealPath(name); err != nil {
 		return nil, &os.PathError{Op: "create", Path: name, Err: err}
 	}
-	return b.source.Create(name)
+	sourcef, err := b.source.Create(name)
+	if err != nil {
+		return nil, err
+	}
+	return &BasePathFile{File: sourcef, path: b.path}, nil
 }
 
 // vim: ts=4 sw=4 noexpandtab nolist syn=go

--- a/basepath.go
+++ b/basepath.go
@@ -29,7 +29,7 @@ type BasePathFile struct {
 
 func (f *BasePathFile) Name() string {
 	sourcename := f.File.Name()
-	return strings.TrimPrefix(sourcename, f.path)
+	return strings.TrimPrefix(sourcename, filepath.Clean(f.path))
 }
 
 func NewBasePathFs(source Fs, path string) Fs {

--- a/basepath_test.go
+++ b/basepath_test.go
@@ -5,7 +5,6 @@ import (
 	"path/filepath"
 	"runtime"
 	"testing"
-	"fmt"
 )
 
 func TestBasePath(t *testing.T) {
@@ -142,7 +141,6 @@ func TestNestedBasePaths(t *testing.T) {
 	}
 }
 
-
 func TestBasePathOpenFile(t *testing.T) {
 	baseFs := &MemMapFs{}
 	baseFs.MkdirAll("/base/path/tmp", 0777)
@@ -178,7 +176,6 @@ func TestBasePathTempFile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to TempDir: %v", err)
 	}
-	fmt.Println(tDir)
 	if filepath.Dir(tDir) != filepath.Clean("/tmp") {
 		t.Fatalf("Tempdir realpath leaked: %s", tDir)
 	}

--- a/basepath_test.go
+++ b/basepath_test.go
@@ -151,7 +151,7 @@ func TestBasePathOpenFile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to open file: %v", err)
 	}
-	if filepath.Dir(f.Name()) != "/tmp" {
+	if filepath.Dir(f.Name()) != filepath.Clean("/tmp") {
 		t.Fatalf("realpath leaked: %s", f.Name())
 	}
 }
@@ -164,7 +164,7 @@ func TestBasePathCreate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create file: %v", err)
 	}
-	if filepath.Dir(f.Name()) != "/tmp" {
+	if filepath.Dir(f.Name()) != filepath.Clean("/tmp") {
 		t.Fatalf("realpath leaked: %s", f.Name())
 	}
 }
@@ -179,7 +179,7 @@ func TestBasePathTempFile(t *testing.T) {
 		t.Fatalf("Failed to TempDir: %v", err)
 	}
 	fmt.Println(tDir)
-	if filepath.Dir(tDir) != "/tmp" {
+	if filepath.Dir(tDir) != filepath.Clean("/tmp") {
 		t.Fatalf("Tempdir realpath leaked: %s", tDir)
 	}
 	tempFile, err := TempFile(bp, tDir, "")


### PR DESCRIPTION
Files returned by the BasePathFs operations don't report a usable name (using `file.Name()`) since they include the prefix, which is prepended a second time by the Fs when passed back. For instance, the following doesn't work:

```go
osfs := afero.NewOsFs()
bfs := afero.NewBasePathFs(osfs, "/some/base/path")
f, _ := bfs.Create("relative/path")
// do some stuff

// This doesn't work since it tries to remove 
// /some/base/path/some/base/path/relative/path
bfs.Remove(f.Name())
```

This is especially irksome when working with TempFiles; basically anything that uses `file.Name()` ends up needing a type switch to get a path usable by the `Fs` object, which breaks the transparency of the Fs abstraction.

I've implemented a simple fix for this: add a `BasePathFile` type with an overridden `Name` method to strip the base path. Not sure if there are more subtle consequences to this, but it seems to work so I figured I'd submit a PR.