### PR TITLE
Removes go 1.7 from the build matrix, adds 1.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ sudo: false
 language: go
 
 go:
-  - 1.7.5
   - 1.8
+  - 1.9
   - tip
 
 os:


### PR DESCRIPTION
Travis builds are failing on go 1.7.5 because of github.com/pkg/sftp doesn't support that version anymore.