### PR TITLE
sftpfs: Implement OpenFile method

### DIFF
--- a/sftpfs/sftp.go
+++ b/sftpfs/sftp.go
@@ -94,8 +94,14 @@ func (s Fs) Open(name string) (afero.File, error) {
 	return FileOpen(s.client, name)
 }
 
+// OpenFile calls the OpenFile method on the SSHFS connection. The mode argument
+// is ignored because it's ignored by the github.com/pkg/sftp implementation.
 func (s Fs) OpenFile(name string, flag int, perm os.FileMode) (afero.File, error) {
-	return nil, nil
+	sshfsFile, err := s.client.OpenFile(name, flag)
+	if err != nil {
+		return nil, err
+	}
+	return &File{fd: sshfsFile}, nil
 }
 
 func (s Fs) Remove(name string) error {


### PR DESCRIPTION
Before, the OpenFile method was unimplemented, and just returned `nil,
nil`. Because the Afero.TempFile method calls the OpenFile method, this
behavior caused a nil pointer exception when TempFile was used with
sftpfs.

This commit adds a simple implementation for sftpfs.OpenFile, fixing the
exception thrown when using it with TempFile.