### PR TITLE
WORK IN PROGRESS: Add an optional Lstater interface

### DIFF
--- a/basepath.go
+++ b/basepath.go
@@ -1,7 +1,6 @@
 package afero
 
 import (
-	"errors"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -42,7 +41,7 @@ func NewBasePathFs(source Fs, path string) Fs {
 // else the given file with the base path prepended
 func (b *BasePathFs) RealPath(name string) (path string, err error) {
 	if err := validateBasePathName(name); err != nil {
-		return "", err
+		return name, err
 	}
 
 	bpath := filepath.Clean(b.path)
@@ -64,7 +63,7 @@ func validateBasePathName(name string) error {
 	// On Windows a common mistake would be to provide an absolute OS path
 	// We could strip out the base part, but that would not be very portable.
 	if filepath.IsAbs(name) {
-		return &os.PathError{Op: "realPath", Path: name, Err: errors.New("got a real OS path instead of a virtual")}
+		return os.ErrNotExist
 	}
 
 	return nil

--- a/basepath_test.go
+++ b/basepath_test.go
@@ -68,8 +68,8 @@ func TestRealPath(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		_, err = bp.RealPath(anotherDir)
 
-		if err == nil {
-			t.Errorf("Expected error")
+		if err != os.ErrNotExist {
+			t.Errorf("Expected os.ErrNotExist")
 		}
 
 	} else {

--- a/cacheOnReadFs.go
+++ b/cacheOnReadFs.go
@@ -205,7 +205,7 @@ func (u *CacheOnReadFs) OpenFile(name string, flag int, perm os.FileMode) (File,
 			bfi.Close() // oops, what if O_TRUNC was set and file opening in the layer failed...?
 			return nil, err
 		}
-		return &UnionFile{base: bfi, layer: lfi}, nil
+		return &UnionFile{Base: bfi, Layer: lfi}, nil
 	}
 	return u.layer.OpenFile(name, flag, perm)
 }
@@ -251,7 +251,7 @@ func (u *CacheOnReadFs) Open(name string) (File, error) {
 	if err != nil && bfile == nil {
 		return nil, err
 	}
-	return &UnionFile{base: bfile, layer: lfile}, nil
+	return &UnionFile{Base: bfile, Layer: lfile}, nil
 }
 
 func (u *CacheOnReadFs) Mkdir(name string, perm os.FileMode) error {
@@ -286,5 +286,5 @@ func (u *CacheOnReadFs) Create(name string) (File, error) {
 		bfh.Close()
 		return nil, err
 	}
-	return &UnionFile{base: bfh, layer: lfh}, nil
+	return &UnionFile{Base: bfh, Layer: lfh}, nil
 }

--- a/composite_test.go
+++ b/composite_test.go
@@ -51,7 +51,6 @@ func CleanupTempDirs(t *testing.T) {
 func TestUnionCreateExisting(t *testing.T) {
 	base := &MemMapFs{}
 	roBase := &ReadOnlyFs{source: base}
-
 	ufs := NewCopyOnWriteFs(roBase, &MemMapFs{})
 
 	base.MkdirAll("/home/test", 0777)

--- a/copyOnWriteFs.go
+++ b/copyOnWriteFs.go
@@ -258,7 +258,7 @@ func (u *CopyOnWriteFs) Open(name string) (File, error) {
 		return nil, fmt.Errorf("BaseErr: %v\nOverlayErr: %v", bErr, lErr)
 	}
 
-	return &UnionFile{base: bfile, layer: lfile}, nil
+	return &UnionFile{Base: bfile, Layer: lfile}, nil
 }
 
 func (u *CopyOnWriteFs) Mkdir(name string, perm os.FileMode) error {

--- a/copyOnWriteFs.go
+++ b/copyOnWriteFs.go
@@ -8,6 +8,8 @@ import (
 	"time"
 )
 
+var _ Lstater = (*CopyOnWriteFs)(nil)
+
 // The CopyOnWriteFs is a union filesystem: a read only base file system with
 // a possibly writeable layer on top. Changes to the file system will only
 // be made in the overlay: Changing an existing file in the base layer which
@@ -76,16 +78,53 @@ func (u *CopyOnWriteFs) Chmod(name string, mode os.FileMode) error {
 func (u *CopyOnWriteFs) Stat(name string) (os.FileInfo, error) {
 	fi, err := u.layer.Stat(name)
 	if err != nil {
-		origErr := err
-		if e, ok := err.(*os.PathError); ok {
-			err = e.Err
-		}
-		if err == os.ErrNotExist || err == syscall.ENOENT || err == syscall.ENOTDIR {
+		isNotExist := u.isNotExist(err)
+		if isNotExist {
 			return u.base.Stat(name)
 		}
-		return nil, origErr
+		return nil, err
 	}
 	return fi, nil
+}
+
+func (u *CopyOnWriteFs) LstatIfPossible(name string) (os.FileInfo, bool, error) {
+	llayer, ok1 := u.layer.(Lstater)
+	lbase, ok2 := u.base.(Lstater)
+
+	if ok1 {
+		fi, b, err := llayer.LstatIfPossible(name)
+		if err == nil {
+			return fi, b, nil
+		}
+
+		if !u.isNotExist(err) {
+			return nil, b, err
+		}
+	}
+
+	if ok2 {
+		fi, b, err := lbase.LstatIfPossible(name)
+		if err == nil {
+			return fi, b, nil
+		}
+		if !u.isNotExist(err) {
+			return nil, b, err
+		}
+	}
+
+	fi, err := u.Stat(name)
+
+	return fi, false, err
+}
+
+func (u *CopyOnWriteFs) isNotExist(err error) bool {
+	if e, ok := err.(*os.PathError); ok {
+		err = e.Err
+	}
+	if err == os.ErrNotExist || err == syscall.ENOENT || err == syscall.ENOTDIR {
+		return true
+	}
+	return false
 }
 
 // Renaming files present only in the base layer is not permitted

--- a/copyOnWriteFs_test.go
+++ b/copyOnWriteFs_test.go
@@ -8,6 +8,7 @@ func TestCopyOnWrite(t *testing.T) {
 	base := NewOsFs()
 	roBase := NewReadOnlyFs(base)
 	ufs := NewCopyOnWriteFs(roBase, NewMemMapFs())
+
 	fs = ufs
 	err = fs.MkdirAll("nonexistent/directory/", 0744)
 	if err != nil {

--- a/lstater.go
+++ b/lstater.go
@@ -1,0 +1,27 @@
+// Copyright © 2018 Steve Francia <spf@spf13.com>.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package afero
+
+import (
+	"os"
+)
+
+// Lstater is an optional interface in Afero. It is only implemented by the
+// filesystems saying so.
+// It will call Lstat if the filesystem iself is, or it delegates to, the os filesystem.
+// Else it will call Stat.
+// In addtion to the FileInfo, it will return a boolean telling whether Lstat was called or not.
+type Lstater interface {
+	LstatIfPossible(name string) (os.FileInfo, bool, error)
+}

--- a/lstater_test.go
+++ b/lstater_test.go
@@ -1,0 +1,102 @@
+// Copyright ©2018 Steve Francia <spf@spf13.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package afero
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLstatIfPossible(t *testing.T) {
+	wd, _ := os.Getwd()
+	defer func() {
+		os.Chdir(wd)
+	}()
+
+	osFs := &OsFs{}
+
+	workDir, err := TempDir(osFs, "", "afero-lstate")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer func() {
+		osFs.RemoveAll(workDir)
+	}()
+
+	memWorkDir := "/lstate"
+
+	memFs := NewMemMapFs()
+	overlayFs1 := &CopyOnWriteFs{base: osFs, layer: memFs}
+	overlayFs2 := &CopyOnWriteFs{base: memFs, layer: osFs}
+	overlayFsMemOnly := &CopyOnWriteFs{base: memFs, layer: NewMemMapFs()}
+	basePathFs := &BasePathFs{source: osFs, path: workDir}
+	basePathFsMem := &BasePathFs{source: memFs, path: memWorkDir}
+	roFs := &ReadOnlyFs{source: osFs}
+	roFsMem := &ReadOnlyFs{source: memFs}
+
+	pathFileMem := filepath.Join(memWorkDir, "aferom.txt")
+
+	WriteFile(osFs, filepath.Join(workDir, "afero.txt"), []byte("Hi, Afero!"), 0777)
+	WriteFile(memFs, filepath.Join(pathFileMem), []byte("Hi, Afero!"), 0777)
+
+	os.Chdir(workDir)
+	if err := os.Symlink("afero.txt", "symafero.txt"); err != nil {
+		t.Fatal(err)
+	}
+
+	pathFile := filepath.Join(workDir, "afero.txt")
+	pathSymlink := filepath.Join(workDir, "symafero.txt")
+
+	checkLstat := func(l Lstater, name string, shouldLstat bool) os.FileInfo {
+		statFile, isLstat, err := l.LstatIfPossible(name)
+		if err != nil {
+			t.Fatalf("Lstat check failed: %s", err)
+		}
+		if isLstat != shouldLstat {
+			t.Fatalf("Lstat status was %t for %s", isLstat, name)
+		}
+		return statFile
+	}
+
+	testLstat := func(l Lstater, pathFile, pathSymlink string) {
+		shouldLstat := pathSymlink != ""
+		statRegular := checkLstat(l, pathFile, shouldLstat)
+		statSymlink := checkLstat(l, pathSymlink, shouldLstat)
+		if statRegular == nil || statSymlink == nil {
+			t.Fatal("got nil FileInfo")
+		}
+
+		symSym := statSymlink.Mode()&os.ModeSymlink == os.ModeSymlink
+		if symSym == (pathSymlink == "") {
+			t.Fatal("expected the FileInfo to describe the symlink")
+		}
+
+		_, _, err := l.LstatIfPossible("this-should-not-exist.txt")
+		if err == nil || !os.IsNotExist(err) {
+			t.Fatalf("expected file to not exist, got %s", err)
+		}
+	}
+
+	testLstat(osFs, pathFile, pathSymlink)
+	testLstat(overlayFs1, pathFile, pathSymlink)
+	testLstat(overlayFs2, pathFile, pathSymlink)
+	testLstat(basePathFs, "afero.txt", "symafero.txt")
+	testLstat(overlayFsMemOnly, pathFileMem, "")
+	testLstat(basePathFsMem, "aferom.txt", "")
+	testLstat(roFs, pathFile, pathSymlink)
+	testLstat(roFsMem, pathFileMem, "")
+}

--- a/match.go
+++ b/match.go
@@ -33,8 +33,8 @@ import (
 // built-ins from that package.
 func Glob(fs Fs, pattern string) (matches []string, err error) {
 	if !hasMeta(pattern) {
-		// afero does not support Lstat directly.
-		if _, err = lstatIfOs(fs, pattern); err != nil {
+		// Lstat not supported by a ll filesystems.
+		if _, err = lstatIfPossible(fs, pattern); err != nil {
 			return nil, nil
 		}
 		return []string{pattern}, nil

--- a/os.go
+++ b/os.go
@@ -19,6 +19,8 @@ import (
 	"time"
 )
 
+var _ Lstater = (*OsFs)(nil)
+
 // OsFs is a Fs implementation that uses functions provided by the os package.
 //
 // For details in any method, check the documentation of the os package
@@ -91,4 +93,9 @@ func (OsFs) Chmod(name string, mode os.FileMode) error {
 
 func (OsFs) Chtimes(name string, atime time.Time, mtime time.Time) error {
 	return os.Chtimes(name, atime, mtime)
+}
+
+func (OsFs) LstatIfPossible(name string) (os.FileInfo, bool, error) {
+	fi, err := os.Lstat(name)
+	return fi, true, err
 }

--- a/readonlyfs.go
+++ b/readonlyfs.go
@@ -6,6 +6,8 @@ import (
 	"time"
 )
 
+var _ Lstater = (*ReadOnlyFs)(nil)
+
 type ReadOnlyFs struct {
 	source Fs
 }
@@ -32,6 +34,14 @@ func (r *ReadOnlyFs) Name() string {
 
 func (r *ReadOnlyFs) Stat(name string) (os.FileInfo, error) {
 	return r.source.Stat(name)
+}
+
+func (r *ReadOnlyFs) LstatIfPossible(name string) (os.FileInfo, bool, error) {
+	if lsf, ok := r.source.(Lstater); ok {
+		return lsf.LstatIfPossible(name)
+	}
+	fi, err := r.Stat(name)
+	return fi, false, err
 }
 
 func (r *ReadOnlyFs) Rename(o, n string) error {

--- a/unionFile.go
+++ b/unionFile.go
@@ -21,32 +21,33 @@ import (
 // successful read in the overlay will move the cursor position in the base layer
 // by the number of bytes read.
 type UnionFile struct {
-	base  File
-	layer File
-	off   int
-	files []os.FileInfo
+	Base   File
+	Layer  File
+	Merger DirsMerger
+	off    int
+	files  []os.FileInfo
 }
 
 func (f *UnionFile) Close() error {
 	// first close base, so we have a newer timestamp in the overlay. If we'd close
 	// the overlay first, we'd get a cacheStale the next time we access this file
 	// -> cache would be useless ;-)
-	if f.base != nil {
-		f.base.Close()
+	if f.Base != nil {
+		f.Base.Close()
 	}
-	if f.layer != nil {
-		return f.layer.Close()
+	if f.Layer != nil {
+		return f.Layer.Close()
 	}
 	return BADFD
 }
 
 func (f *UnionFile) Read(s []byte) (int, error) {
-	if f.layer != nil {
-		n, err := f.layer.Read(s)
-		if (err == nil || err == io.EOF) && f.base != nil {
+	if f.Layer != nil {
+		n, err := f.Layer.Read(s)
+		if (err == nil || err == io.EOF) && f.Base != nil {
 			// advance the file position also in the base file, the next
 			// call may be a write at this position (or a seek with SEEK_CUR)
-			if _, seekErr := f.base.Seek(int64(n), os.SEEK_CUR); seekErr != nil {
+			if _, seekErr := f.Base.Seek(int64(n), os.SEEK_CUR); seekErr != nil {
 				// only overwrite err in case the seek fails: we need to
 				// report an eventual io.EOF to the caller
 				err = seekErr
@@ -54,123 +55,135 @@ func (f *UnionFile) Read(s []byte) (int, error) {
 		}
 		return n, err
 	}
-	if f.base != nil {
-		return f.base.Read(s)
+	if f.Base != nil {
+		return f.Base.Read(s)
 	}
 	return 0, BADFD
 }
 
 func (f *UnionFile) ReadAt(s []byte, o int64) (int, error) {
-	if f.layer != nil {
-		n, err := f.layer.ReadAt(s, o)
-		if (err == nil || err == io.EOF) && f.base != nil {
-			_, err = f.base.Seek(o+int64(n), os.SEEK_SET)
+	if f.Layer != nil {
+		n, err := f.Layer.ReadAt(s, o)
+		if (err == nil || err == io.EOF) && f.Base != nil {
+			_, err = f.Base.Seek(o+int64(n), os.SEEK_SET)
 		}
 		return n, err
 	}
-	if f.base != nil {
-		return f.base.ReadAt(s, o)
+	if f.Base != nil {
+		return f.Base.ReadAt(s, o)
 	}
 	return 0, BADFD
 }
 
 func (f *UnionFile) Seek(o int64, w int) (pos int64, err error) {
-	if f.layer != nil {
-		pos, err = f.layer.Seek(o, w)
-		if (err == nil || err == io.EOF) && f.base != nil {
-			_, err = f.base.Seek(o, w)
+	if f.Layer != nil {
+		pos, err = f.Layer.Seek(o, w)
+		if (err == nil || err == io.EOF) && f.Base != nil {
+			_, err = f.Base.Seek(o, w)
 		}
 		return pos, err
 	}
-	if f.base != nil {
-		return f.base.Seek(o, w)
+	if f.Base != nil {
+		return f.Base.Seek(o, w)
 	}
 	return 0, BADFD
 }
 
 func (f *UnionFile) Write(s []byte) (n int, err error) {
-	if f.layer != nil {
-		n, err = f.layer.Write(s)
-		if err == nil && f.base != nil { // hmm, do we have fixed size files where a write may hit the EOF mark?
-			_, err = f.base.Write(s)
+	if f.Layer != nil {
+		n, err = f.Layer.Write(s)
+		if err == nil && f.Base != nil { // hmm, do we have fixed size files where a write may hit the EOF mark?
+			_, err = f.Base.Write(s)
 		}
 		return n, err
 	}
-	if f.base != nil {
-		return f.base.Write(s)
+	if f.Base != nil {
+		return f.Base.Write(s)
 	}
 	return 0, BADFD
 }
 
 func (f *UnionFile) WriteAt(s []byte, o int64) (n int, err error) {
-	if f.layer != nil {
-		n, err = f.layer.WriteAt(s, o)
-		if err == nil && f.base != nil {
-			_, err = f.base.WriteAt(s, o)
+	if f.Layer != nil {
+		n, err = f.Layer.WriteAt(s, o)
+		if err == nil && f.Base != nil {
+			_, err = f.Base.WriteAt(s, o)
 		}
 		return n, err
 	}
-	if f.base != nil {
-		return f.base.WriteAt(s, o)
+	if f.Base != nil {
+		return f.Base.WriteAt(s, o)
 	}
 	return 0, BADFD
 }
 
 func (f *UnionFile) Name() string {
-	if f.layer != nil {
-		return f.layer.Name()
+	if f.Layer != nil {
+		return f.Layer.Name()
 	}
-	return f.base.Name()
+	return f.Base.Name()
 }
 
-// UnionKey can be implemented to use an alternate key than FileInfo.Name when
-// weaving the two directories together. The use case(s) are uncommon and special,
-// but this will allow a union file system with multiple files with the same filename.
-// This needs to be implemented by your own implementation of os.FileInfo as
-// returned in Readdir.
-type UnionKey interface {
-	AferoUnionKey() string
-}
+// DirsMerger is how UnionFile weaves two directories together.
+// It takes the FileInfo slices from the layer and the base and returns a
+// single view.
+type DirsMerger func(lofi, bofi []os.FileInfo) ([]os.FileInfo, error)
 
-func (f *UnionFile) key(ofi os.FileInfo) string {
-	switch tp := ofi.(type) {
-	case UnionKey:
-		return tp.AferoUnionKey()
-	default:
-		return tp.Name()
+var defaultUnionMergeDirsFn = func(lofi, bofi []os.FileInfo) ([]os.FileInfo, error) {
+	var files = make(map[string]os.FileInfo)
+
+	for _, fi := range lofi {
+		files[fi.Name()] = fi
 	}
+
+	for _, fi := range bofi {
+		if _, exists := files[fi.Name()]; !exists {
+			files[fi.Name()] = fi
+		}
+	}
+
+	rfi := make([]os.FileInfo, len(files))
+
+	i := 0
+	for _, fi := range files {
+		rfi[i] = fi
+		i++
+	}
+
+	return rfi, nil
+
 }
 
 // Readdir will weave the two directories together and
 // return a single view of the overlayed directories
 func (f *UnionFile) Readdir(c int) (ofi []os.FileInfo, err error) {
+	var merge DirsMerger = f.Merger
+	if merge == nil {
+		merge = defaultUnionMergeDirsFn
+	}
+
 	if f.off == 0 {
-		var files = make(map[string]os.FileInfo)
-		var rfi []os.FileInfo
-		if f.layer != nil {
-			rfi, err = f.layer.Readdir(-1)
+		var lfi []os.FileInfo
+		if f.Layer != nil {
+			lfi, err = f.Layer.Readdir(-1)
 			if err != nil {
 				return nil, err
-			}
-			for _, fi := range rfi {
-				files[f.key(fi)] = fi
 			}
 		}
 
-		if f.base != nil {
-			rfi, err = f.base.Readdir(-1)
+		var bfi []os.FileInfo
+		if f.Base != nil {
+			bfi, err = f.Base.Readdir(-1)
 			if err != nil {
 				return nil, err
 			}
-			for _, fi := range rfi {
-				if _, exists := files[fi.Name()]; !exists {
-					files[f.key(fi)] = fi
-				}
-			}
+
 		}
-		for _, fi := range files {
-			f.files = append(f.files, fi)
+		merged, err := merge(lfi, bfi)
+		if err != nil {
+			return nil, err
 		}
+		f.files = append(f.files, merged...)
 	}
 	if c == -1 {
 		return f.files[f.off:], nil
@@ -192,53 +205,53 @@ func (f *UnionFile) Readdirnames(c int) ([]string, error) {
 }
 
 func (f *UnionFile) Stat() (os.FileInfo, error) {
-	if f.layer != nil {
-		return f.layer.Stat()
+	if f.Layer != nil {
+		return f.Layer.Stat()
 	}
-	if f.base != nil {
-		return f.base.Stat()
+	if f.Base != nil {
+		return f.Base.Stat()
 	}
 	return nil, BADFD
 }
 
 func (f *UnionFile) Sync() (err error) {
-	if f.layer != nil {
-		err = f.layer.Sync()
-		if err == nil && f.base != nil {
-			err = f.base.Sync()
+	if f.Layer != nil {
+		err = f.Layer.Sync()
+		if err == nil && f.Base != nil {
+			err = f.Base.Sync()
 		}
 		return err
 	}
-	if f.base != nil {
-		return f.base.Sync()
+	if f.Base != nil {
+		return f.Base.Sync()
 	}
 	return BADFD
 }
 
 func (f *UnionFile) Truncate(s int64) (err error) {
-	if f.layer != nil {
-		err = f.layer.Truncate(s)
-		if err == nil && f.base != nil {
-			err = f.base.Truncate(s)
+	if f.Layer != nil {
+		err = f.Layer.Truncate(s)
+		if err == nil && f.Base != nil {
+			err = f.Base.Truncate(s)
 		}
 		return err
 	}
-	if f.base != nil {
-		return f.base.Truncate(s)
+	if f.Base != nil {
+		return f.Base.Truncate(s)
 	}
 	return BADFD
 }
 
 func (f *UnionFile) WriteString(s string) (n int, err error) {
-	if f.layer != nil {
-		n, err = f.layer.WriteString(s)
-		if err == nil && f.base != nil {
-			_, err = f.base.WriteString(s)
+	if f.Layer != nil {
+		n, err = f.Layer.WriteString(s)
+		if err == nil && f.Base != nil {
+			_, err = f.Base.WriteString(s)
 		}
 		return n, err
 	}
-	if f.base != nil {
-		return f.base.WriteString(s)
+	if f.Base != nil {
+		return f.Base.WriteString(s)
 	}
 	return 0, BADFD
 }


### PR DESCRIPTION
The interface has one method returning the `FileInfo` and a flag telling if `Lstat` was called or not.

```go
type Lstater interface {
    LstatIfPossible(name string) (os.FileInfo, bool, error)
}
```

`Lstat` is currently only supported by the `OsFs`, but since that `Fs` can be used in others, they will also support it by proxy.

But not always, so hence this optional interface.

The interface is in this commit implemented for:

* BasePathFs
* OsFs
* CopyOnWriteFs
* ReadOnlyFs

Fixes #75