### PR TITLE
Return closed error in mem.File.Write() after Close()

### DIFF
--- a/mem/file.go
+++ b/mem/file.go
@@ -230,6 +230,9 @@ func (f *File) Seek(offset int64, whence int) (int64, error) {
 }
 
 func (f *File) Write(b []byte) (n int, err error) {
+	if f.closed == true {
+		return 0, ErrFileClosed
+	}
 	if f.readOnly {
 		return 0, &os.PathError{Op: "write", Path: f.fileData.name, Err: errors.New("file handle is read only")}
 	}


### PR DESCRIPTION
Fixes #166 