### PR TITLE
Fix MemMapFs RealPath error when BasePath = ""

### DIFF
--- a/basepath.go
+++ b/basepath.go
@@ -46,7 +46,7 @@ func (b *BasePathFs) RealPath(name string) (path string, err error) {
 
 	bpath := filepath.Clean(b.path)
 	path = filepath.Clean(filepath.Join(bpath, name))
-	if !strings.HasPrefix(path, bpath) {
+	if bpath != "." && !strings.HasPrefix(path, bpath) {
 		return name, os.ErrNotExist
 	}
 


### PR DESCRIPTION
bpath cleans to ".", but paths "./*" clean to "*".

This results in "." not found as prefix of "*" except
for hidden files and dirs.

Skip the prefix check if bpath == "." as this is
lexically equivalent to "", which would satisfy the
check.