### PR TITLE
Fix UnionFile.Readdir with non -1

### DIFF
--- a/unionFile.go
+++ b/unionFile.go
@@ -185,11 +185,17 @@ func (f *UnionFile) Readdir(c int) (ofi []os.FileInfo, err error) {
 		}
 		f.files = append(f.files, merged...)
 	}
-	if c == -1 {
-		return f.files[f.off:], nil
+	if c <= 0 || f.off+c >= len(f.files) {
+		results := f.files[f.off:]
+		f.off = len(f.files)
+		if len(results) == 0 {
+			return nil, io.EOF
+		}
+		return results, nil
 	}
-	defer func() { f.off += c }()
-	return f.files[f.off:c], nil
+	results := f.files[f.off : f.off+c]
+	f.off += c
+	return results, nil
 }
 
 func (f *UnionFile) Readdirnames(c int) ([]string, error) {

--- a/unionFile_test.go
+++ b/unionFile_test.go
@@ -1,0 +1,109 @@
+package afero
+
+import (
+	"io"
+	"testing"
+)
+
+func TestUnionFileReaddir(t *testing.T) {
+	base := &MemMapFs{}
+	layer := &MemMapFs{}
+
+	WriteFile(base, "foo", []byte{'F'}, 0)
+	WriteFile(layer, "bar", []byte{'B'}, 0)
+
+	openUnionFile := func() (*UnionFile, error) {
+		basef, err := base.Open("/")
+		if err != nil {
+			return nil, err
+		}
+		layerf, err := layer.Open("/")
+		if err != nil {
+			basef.Close()
+			return nil, err
+		}
+		return &UnionFile{
+			Base:  basef,
+			Layer: layerf,
+		}, nil
+	}
+
+	t.Run("Readdir(-1)", func(t *testing.T) {
+		f, err := openUnionFile()
+		if err != nil {
+			t.Error(err)
+			return
+		}
+		defer f.Close()
+		files, err := f.Readdir(-1)
+		if err != nil {
+			t.Error(err)
+			return
+		}
+		if len(files) != 2 {
+			t.Fatal("invalid files returned from Readdir")
+			return
+		}
+		_, err = f.Readdir(1)
+		if err != io.EOF {
+			t.Fatal("Readdir did not return EOF")
+			return
+		}
+	})
+
+	t.Run("Readdir(1000)", func(t *testing.T) {
+		f, err := openUnionFile()
+		if err != nil {
+			t.Error(err)
+			return
+		}
+		defer f.Close()
+		files, err := f.Readdir(1000)
+		if err != nil {
+			t.Error(err)
+			return
+		}
+		if len(files) != 2 {
+			t.Fatal("invalid files returned Readdir")
+			return
+		}
+		_, err = f.Readdir(1)
+		if err != io.EOF {
+			t.Fatal("Readdir did not return EOF")
+			return
+		}
+	})
+
+	t.Run("Readdir(1) x 2", func(t *testing.T) {
+		f, err := openUnionFile()
+		if err != nil {
+			t.Error(err)
+			return
+		}
+		defer f.Close()
+		files1, err := f.Readdir(1)
+		if err != nil {
+			t.Error(err)
+			return
+		}
+		if len(files1) != 1 {
+			t.Fatal("invalid files returned from Readdir")
+			return
+		}
+		files2, err := f.Readdir(1)
+		if err != nil {
+			t.Error(err)
+			return
+		}
+		if len(files2) != 1 {
+			t.Fatal("invalid files returned from Readdir")
+			return
+		}
+		_, err = f.Readdir(1)
+		if err != io.EOF {
+			t.Fatal("Readdir did not return EOF")
+			return
+		}
+	})
+
+}


### PR DESCRIPTION
Fixes UnionFile.Readdir(c), you'll see how ```unionFile_test.go``` fails on master