### PR TITLE
Make constructors return structs instead of interfaces

### DIFF
--- a/basepath.go
+++ b/basepath.go
@@ -9,6 +9,7 @@ import (
 )
 
 var _ Lstater = (*BasePathFs)(nil)
+var _ Fs = (*BasePathFs)(nil)
 
 // The BasePathFs restricts all operations to a given path within an Fs.
 // The given file name to the operations on this Fs will be prepended with
@@ -33,7 +34,7 @@ func (f *BasePathFile) Name() string {
 	return strings.TrimPrefix(sourcename, filepath.Clean(f.path))
 }
 
-func NewBasePathFs(source Fs, path string) Fs {
+func NewBasePathFs(source Fs, path string) *BasePathFs {
 	return &BasePathFs{source: source, path: path}
 }
 

--- a/basepath_test.go
+++ b/basepath_test.go
@@ -51,7 +51,7 @@ func TestRealPath(t *testing.T) {
 	}
 	defer fs.RemoveAll(anotherDir)
 
-	bp := NewBasePathFs(fs, baseDir).(*BasePathFs)
+	bp := NewBasePathFs(fs, baseDir)
 
 	subDir := filepath.Join(baseDir, "s1")
 

--- a/cacheOnReadFs.go
+++ b/cacheOnReadFs.go
@@ -6,6 +6,8 @@ import (
 	"time"
 )
 
+var _ Fs = (*CacheOnReadFs)(nil)
+
 // If the cache duration is 0, cache time will be unlimited, i.e. once
 // a file is in the layer, the base will never be read again for this file.
 //
@@ -25,7 +27,7 @@ type CacheOnReadFs struct {
 	cacheTime time.Duration
 }
 
-func NewCacheOnReadFs(base Fs, layer Fs, cacheTime time.Duration) Fs {
+func NewCacheOnReadFs(base Fs, layer Fs, cacheTime time.Duration) *CacheOnReadFs {
 	return &CacheOnReadFs{base: base, layer: layer, cacheTime: cacheTime}
 }
 

--- a/copyOnWriteFs.go
+++ b/copyOnWriteFs.go
@@ -9,6 +9,7 @@ import (
 )
 
 var _ Lstater = (*CopyOnWriteFs)(nil)
+var _ Fs = (*CopyOnWriteFs)(nil)
 
 // The CopyOnWriteFs is a union filesystem: a read only base file system with
 // a possibly writeable layer on top. Changes to the file system will only
@@ -22,7 +23,7 @@ type CopyOnWriteFs struct {
 	layer Fs
 }
 
-func NewCopyOnWriteFs(base Fs, layer Fs) Fs {
+func NewCopyOnWriteFs(base Fs, layer Fs) *CopyOnWriteFs {
 	return &CopyOnWriteFs{base: base, layer: layer}
 }
 

--- a/memmap.go
+++ b/memmap.go
@@ -25,13 +25,15 @@ import (
 	"github.com/spf13/afero/mem"
 )
 
+var _ Fs = (*MemMapFs)(nil)
+
 type MemMapFs struct {
 	mu   sync.RWMutex
 	data map[string]*mem.FileData
 	init sync.Once
 }
 
-func NewMemMapFs() Fs {
+func NewMemMapFs() *MemMapFs {
 	return &MemMapFs{}
 }
 

--- a/os.go
+++ b/os.go
@@ -20,6 +20,7 @@ import (
 )
 
 var _ Lstater = (*OsFs)(nil)
+var _ Fs = (*OsFs)(nil)
 
 // OsFs is a Fs implementation that uses functions provided by the os package.
 //
@@ -27,7 +28,7 @@ var _ Lstater = (*OsFs)(nil)
 // (http://golang.org/pkg/os/).
 type OsFs struct{}
 
-func NewOsFs() Fs {
+func NewOsFs() *OsFs {
 	return &OsFs{}
 }
 

--- a/readonlyfs.go
+++ b/readonlyfs.go
@@ -7,12 +7,13 @@ import (
 )
 
 var _ Lstater = (*ReadOnlyFs)(nil)
+var _ Fs = (*ReadOnlyFs)(nil)
 
 type ReadOnlyFs struct {
 	source Fs
 }
 
-func NewReadOnlyFs(source Fs) Fs {
+func NewReadOnlyFs(source Fs) *ReadOnlyFs {
 	return &ReadOnlyFs{source: source}
 }
 

--- a/regexpfs.go
+++ b/regexpfs.go
@@ -7,6 +7,8 @@ import (
 	"time"
 )
 
+var _ Fs = (*RegexpFs)(nil)
+
 // The RegexpFs filters files (not directories) by regular expression. Only
 // files matching the given regexp will be allowed, all others get a ENOENT error (
 // "No such file or directory").
@@ -16,7 +18,7 @@ type RegexpFs struct {
 	source Fs
 }
 
-func NewRegexpFs(source Fs, re *regexp.Regexp) Fs {
+func NewRegexpFs(source Fs, re *regexp.Regexp) *RegexpFs {
 	return &RegexpFs{source: source, re: re}
 }
 


### PR DESCRIPTION
This changes the return type of the various `NewXxxx` functions from `Fs` to the relevant type that's being returned.

To maintain the same level of compile-time checking, each type impacted now has a `var _ Fs = (*TheType)(nil)` no-op assignment to assert that the type implements `Fs`.

This change brings afero more in line with the ["accept interfaces, return structs" idiom](http://idiomaticgo.com/post/best-practice/accept-interfaces-return-structs/).

Importantly, this makes the constructor functions easier to discover in GoDoc since they will now be grouped with the structs that they build.

AFAIK, this should be completely backwards compatible despite changing the API because:

* The values are still assignable to `Fs`
* Interfaces are transparent to reflection

Edit: I suppose this would be a breaking change if anybody assigned the constructor to a value. Seems unlikely, but plausible. Would that require a major version bump?

Edit 2: This also breaks any code that performs a type assertion on the returned value (by making the assertion unnecessary).

Fixes https://github.com/spf13/afero/issues/76