### PR TITLE
add ReadAt/Seek test

### DIFF
--- a/mem/file.go
+++ b/mem/file.go
@@ -193,8 +193,11 @@ func (f *File) Read(b []byte) (n int, err error) {
 }
 
 func (f *File) ReadAt(b []byte, off int64) (n int, err error) {
+	prev := atomic.LoadInt64(&f.at)
 	atomic.StoreInt64(&f.at, off)
-	return f.Read(b)
+	n, err = f.Read(b)
+	atomic.StoreInt64(&f.at, prev)
+	return
 }
 
 func (f *File) Truncate(size int64) error {


### PR DESCRIPTION
This PR demonstrates a deviation from the `io.ReaderAt` API contract in the mem.File implementation.

> If ReadAt is reading from an input source with a seek offset, ReadAt should not affect nor be affected by the underlying seek offset.

https://github.com/spf13/afero/blob/d40851caa0d747393da1ffb28f7f9d8b4eeffebd/mem/file.go#L195

The PR modifies the mem.File impl to respect the contract by storing the original offset before the Read and restoring the offset after the Read.