### PR TITLE
readme: Add a note about etcdfs

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,16 @@ system using InMemoryFile.
 Afero has experimental support for secure file transfer protocol (sftp). Which can
 be used to perform file operations over a encrypted channel.
 
+## Distributed Backends
+
+## EtcdFs
+
+Afero has experimental support for a simple `[etcd](https://github.com/coreos/etcd)`
+interface. It was built for distributing mostly read-only filesystems across a
+cluster. It is available in the [mgmt project](https://github.com/purpleidea/mgmt/tree/master/etcd/fs)
+and can be imported from there. Performance, large files, and concurrency have
+not been extensively tested. More tests and improved documentation are welcome.
+
 ## Filtering Backends
 
 ### BasePathFs


### PR DESCRIPTION
An etcdfs afero backend is available as part of the mgmt project at:
https://github.com/purpleidea/mgmt/tree/master/etcd/fs

I'll be maintaining it upstream there for now, but in the future we can
discuss moving it here if that makes sense. This note will hopefully aid
to tell interested users about the backend so that they don't have to
duplicate work if that's something they're interested in!