### PR TITLE
Fix UnionFile.Readdir return when c <= 0

### DIFF
--- a/composite_test.go
+++ b/composite_test.go
@@ -404,7 +404,7 @@ func TestCacheOnReadFsNotInLayer(t *testing.T) {
 }
 
 // #194
-func TestUniontFileReaddirEmpty(t *testing.T) {
+func TestUnionFileReaddirEmpty(t *testing.T) {
 	osFs := NewOsFs()
 
 	base := NewMemMapFs()
@@ -439,7 +439,41 @@ func TestUniontFileReaddirEmpty(t *testing.T) {
 	}
 }
 
-func TestUniontFileReaddirAskForTooMany(t *testing.T) {
+// #197
+func TestUnionFileReaddirDuplicateEmpty(t *testing.T) {
+	base := NewMemMapFs()
+	dir, err := TempDir(base, "", "empty-dir")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Overlay shares same empty directory as base
+	overlay := NewMemMapFs()
+	err = overlay.Mkdir(dir, 0700)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ufs := &CopyOnWriteFs{base: base, layer: overlay}
+
+	f, err := ufs.Open(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	names, err := f.Readdirnames(0)
+
+	if err == io.EOF {
+		t.Errorf("unexpected io.EOF error")
+	}
+
+	if len(names) != 0 {
+		t.Fatal("should be empty")
+	}
+}
+
+func TestUnionFileReaddirAskForTooMany(t *testing.T) {
 	base := &MemMapFs{}
 	overlay := &MemMapFs{}
 

--- a/unionFile.go
+++ b/unionFile.go
@@ -155,8 +155,8 @@ var defaultUnionMergeDirsFn = func(lofi, bofi []os.FileInfo) ([]os.FileInfo, err
 }
 
 // Readdir will weave the two directories together and
-// return a single view of the overlayed directories
-// At the end of the directory view, the error is io.EOF.
+// return a single view of the overlayed directories.
+// At the end of the directory view, the error is io.EOF if c > 0.
 func (f *UnionFile) Readdir(c int) (ofi []os.FileInfo, err error) {
 	var merge DirsMerger = f.Merger
 	if merge == nil {
@@ -187,11 +187,15 @@ func (f *UnionFile) Readdir(c int) (ofi []os.FileInfo, err error) {
 		f.files = append(f.files, merged...)
 	}
 
+	if c <= 0 && len(f.files) == 0 {
+		return f.files, nil
+	}
+
 	if f.off >= len(f.files) {
 		return nil, io.EOF
 	}
 
-	if c == -1 {
+	if c <= 0 {
 		return f.files[f.off:], nil
 	}
 


### PR DESCRIPTION
Update Readdir to match behavior of stdlib os package.

Fixes #197