### PR TITLE
Remove stale release notes from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,28 +406,7 @@ Googles very well.
 
 ## Release Notes
 
-* **0.10.0** 2015.12.10
-  * Full compatibility with Windows
-  * Introduction of afero utilities
-  * Test suite rewritten to work cross platform
-  * Normalize paths for MemMapFs
-  * Adding Sync to the file interface
-  * **Breaking Change** Walk and ReadDir have changed parameter order
-  * Moving types used by MemMapFs to a subpackage
-  * General bugfixes and improvements
-* **0.9.0** 2015.11.05
-  * New Walk function similar to filepath.Walk
-  * MemMapFs.OpenFile handles O_CREATE, O_APPEND, O_TRUNC
-  * MemMapFs.Remove now really deletes the file
-  * InMemoryFile.Readdir and Readdirnames work correctly
-  * InMemoryFile functions lock it for concurrent access
-  * Test suite improvements
-* **0.8.0** 2014.10.28
-  * First public version
-  * Interfaces feel ready for people to build using
-  * Interfaces satisfy all known uses
-  * MemMapFs passes the majority of the OS test suite
-  * OsFs passes the majority of the OS test suite
+See the [Releases Page](https://github.com/spf13/afero/releases).
 
 ## Contributing
 


### PR DESCRIPTION
New users coming to the project could incorrectly assume that the project is pre-1.0 release and that it hasn't had a release in years if they assumed that the release notes in the README were up-to-date. I say this because I assumed that on my first read.