### PR TITLE
Proper root init for MemMapFs in windows

### DIFF
--- a/basepath.go
+++ b/basepath.go
@@ -30,7 +30,9 @@ type BasePathFile struct {
 
 func (f *BasePathFile) Name() string {
 	sourcename := f.File.Name()
-	return strings.TrimPrefix(sourcename, filepath.Clean(f.path))
+	sourcename = strings.TrimPrefix(sourcename, filepath.VolumeName(sourcename))
+	sourcename = strings.TrimPrefix(sourcename, filepath.Clean(f.path))
+	return sourcename
 }
 
 func NewBasePathFs(source Fs, path string) Fs {

--- a/composite_test.go
+++ b/composite_test.go
@@ -479,7 +479,7 @@ func TestUnionFileReaddirAskForTooMany(t *testing.T) {
 	overlay := &MemMapFs{}
 
 	for i := 0; i < 5; i++ {
-		WriteFile(base, fmt.Sprintf("file%d.txt", i), []byte("afero"), 0777)
+		WriteFile(base, fmt.Sprintf("/file%d.txt", i), []byte("afero"), 0777)
 	}
 
 	ufs := &CopyOnWriteFs{base: base, layer: overlay}

--- a/composite_test.go
+++ b/composite_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"path/filepath"
+	// "path/filepath"
 	"os"
 	"testing"
 	"time"
@@ -479,21 +479,12 @@ func TestUnionFileReaddirAskForTooMany(t *testing.T) {
 	overlay := &MemMapFs{}
 
 	for i := 0; i < 5; i++ {
-		file, err := filepath.Abs(fmt.Sprintf("/file%d.txt", i))
-		if err != nil {
-			t.Fatal(err)
-		}
-		WriteFile(base, file, []byte("afero"), 0777)
+		WriteFile(base, fmt.Sprintf("file%d.txt", i), []byte("afero"), 0777)
 	}
 
 	ufs := &CopyOnWriteFs{base: base, layer: overlay}
-
-	root, err := filepath.Abs("/")
-	if err != nil {
-		t.Fatal(err)
-	}
 	
-	f, err := ufs.Open(root)
+	f, err := ufs.Open("")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/composite_test.go
+++ b/composite_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"path/filepath"
 	"os"
 	"testing"
 	"time"
@@ -478,12 +479,21 @@ func TestUnionFileReaddirAskForTooMany(t *testing.T) {
 	overlay := &MemMapFs{}
 
 	for i := 0; i < 5; i++ {
-		WriteFile(base, fmt.Sprintf("file%d.txt", i), []byte("afero"), 0777)
+		file, err := filepath.Abs(fmt.Sprintf("/file%d.txt", i))
+		if err != nil {
+			t.Fatal(err)
+		}
+		WriteFile(base, file, []byte("afero"), 0777)
 	}
 
 	ufs := &CopyOnWriteFs{base: base, layer: overlay}
 
-	f, err := ufs.Open("")
+	root, err := filepath.Abs("/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	
+	f, err := ufs.Open(root)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/composite_test.go
+++ b/composite_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	// "path/filepath"
 	"os"
 	"testing"
 	"time"
@@ -483,7 +482,7 @@ func TestUnionFileReaddirAskForTooMany(t *testing.T) {
 	}
 
 	ufs := &CopyOnWriteFs{base: base, layer: overlay}
-	
+
 	f, err := ufs.Open("")
 	if err != nil {
 		t.Fatal(err)

--- a/memmap.go
+++ b/memmap.go
@@ -38,9 +38,13 @@ func NewMemMapFs() Fs {
 func (m *MemMapFs) getData() map[string]*mem.FileData {
 	m.init.Do(func() {
 		m.data = make(map[string]*mem.FileData)
-		// Root should always exist, right?
-		// TODO: what about windows?
-		m.data[FilePathSeparator] = mem.CreateDir(FilePathSeparator)
+		// Root should always exist
+		absolutePath, err := filepath.Abs(FilePathSeparator)
+		if err != nil {
+			log.Fatal(err)
+			panic(err)
+		}
+		m.data[absolutePath] = mem.CreateDir(absolutePath)
 	})
 	return m.data
 }
@@ -48,7 +52,12 @@ func (m *MemMapFs) getData() map[string]*mem.FileData {
 func (*MemMapFs) Name() string { return "MemMapFS" }
 
 func (m *MemMapFs) Create(name string) (File, error) {
-	name = normalizePath(name)
+	var err error
+	name, err = normalizePath(name)
+	if err != nil {
+		return nil, err
+	}
+	
 	m.mu.Lock()
 	file := mem.CreateFile(name)
 	m.getData()[name] = file
@@ -109,7 +118,12 @@ func (m *MemMapFs) registerWithParent(f *mem.FileData) {
 }
 
 func (m *MemMapFs) lockfreeMkdir(name string, perm os.FileMode) error {
-	name = normalizePath(name)
+	var err error
+	name, err = normalizePath(name)
+	if err != nil {
+		return err
+	}
+
 	x, ok := m.getData()[name]
 	if ok {
 		// Only return ErrFileExists if it's a file, not a directory.
@@ -126,7 +140,11 @@ func (m *MemMapFs) lockfreeMkdir(name string, perm os.FileMode) error {
 }
 
 func (m *MemMapFs) Mkdir(name string, perm os.FileMode) error {
-	name = normalizePath(name)
+	var err error
+	name, err = normalizePath(name)
+	if err != nil {
+		return err
+	}
 
 	m.mu.RLock()
 	_, ok := m.getData()[name]
@@ -158,16 +176,22 @@ func (m *MemMapFs) MkdirAll(path string, perm os.FileMode) error {
 }
 
 // Handle some relative paths
-func normalizePath(path string) string {
+func normalizePath(path string) (string, error) {
 	path = filepath.Clean(path)
+	rootAbs, err := filepath.Abs(FilePathSeparator)
+	if err != nil {
+		return "", err
+	}
 
 	switch path {
 	case ".":
-		return FilePathSeparator
+		return rootAbs, nil
 	case "..":
-		return FilePathSeparator
+		return rootAbs, nil
+	case FilePathSeparator:
+		return rootAbs, nil
 	default:
-		return path
+		return path, nil
 	}
 }
 
@@ -188,7 +212,12 @@ func (m *MemMapFs) openWrite(name string) (File, error) {
 }
 
 func (m *MemMapFs) open(name string) (*mem.FileData, error) {
-	name = normalizePath(name)
+	var err error
+	name, err = normalizePath(name)
+	if err != nil {
+		return nil, err
+	}
+	
 
 	m.mu.RLock()
 	f, ok := m.getData()[name]
@@ -200,7 +229,12 @@ func (m *MemMapFs) open(name string) (*mem.FileData, error) {
 }
 
 func (m *MemMapFs) lockfreeOpen(name string) (*mem.FileData, error) {
-	name = normalizePath(name)
+	var err error
+	name, err = normalizePath(name)
+	if err != nil {
+		return nil, err
+	}
+	
 	f, ok := m.getData()[name]
 	if ok {
 		return f, nil
@@ -243,7 +277,12 @@ func (m *MemMapFs) OpenFile(name string, flag int, perm os.FileMode) (File, erro
 }
 
 func (m *MemMapFs) Remove(name string) error {
-	name = normalizePath(name)
+	var err error
+	name, err = normalizePath(name)
+	if err != nil {
+		return err
+	}
+	
 
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -261,7 +300,12 @@ func (m *MemMapFs) Remove(name string) error {
 }
 
 func (m *MemMapFs) RemoveAll(path string) error {
-	path = normalizePath(path)
+	var err error
+	path, err = normalizePath(path)
+	if err != nil {
+		return err
+	}
+	
 	m.mu.Lock()
 	m.unRegisterWithParent(path)
 	m.mu.Unlock()
@@ -282,8 +326,16 @@ func (m *MemMapFs) RemoveAll(path string) error {
 }
 
 func (m *MemMapFs) Rename(oldname, newname string) error {
-	oldname = normalizePath(oldname)
-	newname = normalizePath(newname)
+	var err error
+	oldname, err = normalizePath(oldname)
+	if err != nil {
+		return err
+	}
+	
+	newname, err = normalizePath(newname)
+	if err != nil {
+		return err
+	}
 
 	if oldname == newname {
 		return nil
@@ -318,7 +370,12 @@ func (m *MemMapFs) Stat(name string) (os.FileInfo, error) {
 }
 
 func (m *MemMapFs) Chmod(name string, mode os.FileMode) error {
-	name = normalizePath(name)
+	var err error
+	name, err = normalizePath(name)
+	if err != nil {
+		return err
+	}
+	
 
 	m.mu.RLock()
 	f, ok := m.getData()[name]
@@ -335,7 +392,12 @@ func (m *MemMapFs) Chmod(name string, mode os.FileMode) error {
 }
 
 func (m *MemMapFs) Chtimes(name string, atime time.Time, mtime time.Time) error {
-	name = normalizePath(name)
+	var err error
+	name, err = normalizePath(name)
+	if err != nil {
+		return err
+	}
+	
 
 	m.mu.RLock()
 	f, ok := m.getData()[name]

--- a/memmap.go
+++ b/memmap.go
@@ -191,7 +191,7 @@ func normalizePath(path string) (string, error) {
 	case FilePathSeparator:
 		return rootAbs, nil
 	default:
-		return path, nil
+		return filepath.Abs(path)
 	}
 }
 

--- a/memmap_test.go
+++ b/memmap_test.go
@@ -16,17 +16,25 @@ func TestNormalizePath(t *testing.T) {
 		expected string
 	}
 
+	rootAbs, err := filepath.Abs(FilePathSeparator)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	data := []test{
-		{".", FilePathSeparator},
-		{"./", FilePathSeparator},
-		{"..", FilePathSeparator},
-		{"../", FilePathSeparator},
-		{"./..", FilePathSeparator},
-		{"./../", FilePathSeparator},
+		{".", rootAbs},
+		{"./", rootAbs},
+		{"..", rootAbs},
+		{"../", rootAbs},
+		{"./..", rootAbs},
+		{"./../", rootAbs},
 	}
 
 	for i, d := range data {
-		cpath := normalizePath(d.input)
+		cpath, err := normalizePath(d.input)
+		if err != nil {
+			t.Error(err)
+		}
 		if d.expected != cpath {
 			t.Errorf("Test %d failed. Expected %q got %q", i, d.expected, cpath)
 		}

--- a/util_test.go
+++ b/util_test.go
@@ -75,7 +75,7 @@ func TestIsDir(t *testing.T) {
 	data := []test{
 		{"./", true},
 		{"/", true},
-		{"./this-directory-does-not-existi", false},
+		{"./this-directory-does-not-exist", false},
 		{"/this-absolute-directory/does-not-exist", false},
 	}
 


### PR DESCRIPTION
Fixes #225 

### Problem:
MemMapFs is set to initialize with a map data structure and a root path was added to it. The path that was added uses the `os.PathSeparator` as the root path. While UNIX has no problem with this, Windows does as the volume name is not present in `os.PathSeparator`

### Changes:
* MemMapFs `getData()` init is now changed to add a root absolute instead of `FilePathSeparator`
* `normalizePath(path string) string` is changed to return a proper root absolute if the cleaned path results in a root path (`/` or `\\`) and an error
* BasePathFs removes volume name from path when `Name() string` is called to hide real path
* Several tests are changed to implement the changes