### PR TITLE
MemMapFs, CopyOnWriteFs: Require parent directory on creates

### DIFF
--- a/afero.go
+++ b/afero.go
@@ -26,6 +26,7 @@ import (
 	"errors"
 	"io"
 	"os"
+	"syscall"
 	"time"
 )
 
@@ -105,4 +106,11 @@ var (
 	ErrFileNotFound      = os.ErrNotExist
 	ErrFileExists        = os.ErrExist
 	ErrDestinationExists = os.ErrExist
+	ErrNotDir            = syscall.ENOTDIR
 )
+
+// IsNotDir returns a boolean indicating whether the error is known to report when encountering a file along a path intended for a new directory. It is satisfied by ErrNotDir as well as some syscall errors.
+func IsNotDir(err error) bool {
+	pathErr, ok := err.(*os.PathError)
+	return err == ErrNotDir || (ok && pathErr.Unwrap() == ErrNotDir)
+}

--- a/afero_test.go
+++ b/afero_test.go
@@ -716,3 +716,17 @@ func checkSize(t *testing.T, f File, size int64) {
 		t.Errorf("Stat %q: size %d want %d", f.Name(), dir.Size(), size)
 	}
 }
+
+func TestIsNotDir(t *testing.T) {
+	if IsNotDir(nil) {
+		t.Error("IsNotDir(nil) should be false")
+	}
+
+	if !IsNotDir(ErrNotDir) {
+		t.Error("IsNotDir(ErrNotDir) should be true")
+	}
+
+	if !IsNotDir(&os.PathError{Err: ErrNotDir}) {
+		t.Error("IsNotDir(PathError{ErrNotDir}) should be true")
+	}
+}

--- a/cacheOnReadFs.go
+++ b/cacheOnReadFs.go
@@ -2,6 +2,7 @@ package afero
 
 import (
 	"os"
+	"path/filepath"
 	"syscall"
 	"time"
 )
@@ -279,6 +280,13 @@ func (u *CacheOnReadFs) Create(name string) (File, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	// since base succeeded, ensure directory exists in layer too
+	err = u.MkdirAll(filepath.Dir(normalizePath(name)), 0700)
+	if err != nil {
+		return nil, err
+	}
+
 	lfh, err := u.layer.Create(name)
 	if err != nil {
 		// oops, see comment about OS_TRUNC above, should we remove? then we have to

--- a/cacheOnReadFs_test.go
+++ b/cacheOnReadFs_test.go
@@ -1,0 +1,17 @@
+package afero
+
+import "testing"
+
+func TestCacheOnRead_CreateShouldSyncDirectories(t *testing.T) {
+	base := &MemMapFs{}
+	layer := &MemMapFs{}
+
+	ufs := NewCacheOnReadFs(base, layer, 0)
+
+	base.Mkdir("/data", 0777)
+
+	_, err := ufs.Create("/data/file.txt")
+	if err != nil {
+		t.Error("Cache should create intermediate directories if base.Create succeeds. Failed:", err)
+	}
+}

--- a/composite_test.go
+++ b/composite_test.go
@@ -449,10 +449,6 @@ func TestUnionFileReaddirDuplicateEmpty(t *testing.T) {
 
 	// Overlay shares same empty directory as base
 	overlay := NewMemMapFs()
-	err = overlay.Mkdir(dir, 0700)
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	ufs := &CopyOnWriteFs{base: base, layer: overlay}
 

--- a/copyOnWriteFs_test.go
+++ b/copyOnWriteFs_test.go
@@ -60,3 +60,20 @@ func TestCopyOnWriteFileInMemMapBase(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestCopyOnWriteMkdir(t *testing.T) {
+	memFs := NewMemMapFs()
+	osFs := NewOsFs()
+	writeDir, err := TempDir(osFs, "", "copy-on-write-test")
+	if err != nil {
+		t.Fatal("error creating tempDir", err)
+	}
+	defer osFs.RemoveAll(writeDir)
+
+	compositeFs := NewCopyOnWriteFs(NewReadOnlyFs(osFs), memFs)
+
+	err = compositeFs.Mkdir(filepath.Join(writeDir, "some/path"), 0700)
+	if !os.IsNotExist(err) {
+		t.Fatal("Mkdir should fail if parent directory does not exist:", err)
+	}
+}

--- a/copyOnWriteFs_test.go
+++ b/copyOnWriteFs_test.go
@@ -61,6 +61,7 @@ func TestCopyOnWriteFileInMemMapBase(t *testing.T) {
 	}
 }
 
+// Related: https://github.com/spf13/afero/issues/149
 func TestCopyOnWriteMkdir(t *testing.T) {
 	memFs := NewMemMapFs()
 	osFs := NewOsFs()

--- a/ioutil.go
+++ b/ioutil.go
@@ -179,6 +179,10 @@ func TempFile(fs Fs, dir, pattern string) (f File, err error) {
 	if dir == "" {
 		dir = os.TempDir()
 	}
+	err = fs.MkdirAll(dir, 0700) // temp dir on some systems is several directories deep, but may not exist in 'fs' yet
+	if err != nil {
+		return
+	}
 
 	var prefix, suffix string
 	if pos := strings.LastIndex(pattern, "*"); pos != -1 {
@@ -217,6 +221,10 @@ func (a Afero) TempDir(dir, prefix string) (name string, err error) {
 func TempDir(fs Fs, dir, prefix string) (name string, err error) {
 	if dir == "" {
 		dir = os.TempDir()
+	}
+	err = fs.MkdirAll(dir, 0700) // temp dir on some systems is several directories deep, but may not exist in 'fs' yet
+	if err != nil {
+		return
 	}
 
 	nconflict := 0

--- a/ioutil_test.go
+++ b/ioutil_test.go
@@ -179,9 +179,9 @@ func TestLongTempPaths(t *testing.T) {
 	// Some platforms have multi-level temp dirs,
 	// so prepend a base path to always test multi-level.
 	t.Run("TempDir", func(t *testing.T) {
-		fs := NewBasePathFs(NewMemMapFs(), "/some/base")
+		fs := NewMemMapFs()
 
-		dir, err := TempDir(fs, "", "")
+		dir, err := TempDir(fs, "/some/base", "")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -192,9 +192,9 @@ func TestLongTempPaths(t *testing.T) {
 	})
 
 	t.Run("TempFile", func(t *testing.T) {
-		fs := NewBasePathFs(NewMemMapFs(), "/some/base")
+		fs := NewMemMapFs()
 
-		file, err := TempFile(fs, "", "")
+		file, err := TempFile(fs, "/some/base", "")
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/ioutil_test.go
+++ b/ioutil_test.go
@@ -174,3 +174,33 @@ func TestTempFile(t *testing.T) {
 		})
 	}
 }
+
+func TestLongTempPaths(t *testing.T) {
+	// Some platforms have multi-level temp dirs,
+	// so prepend a base path to always test multi-level.
+	t.Run("TempDir", func(t *testing.T) {
+		fs := NewBasePathFs(NewMemMapFs(), "/some/base")
+
+		dir, err := TempDir(fs, "", "")
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, err = fs.Stat(dir)
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("TempFile", func(t *testing.T) {
+		fs := NewBasePathFs(NewMemMapFs(), "/some/base")
+
+		file, err := TempFile(fs, "", "")
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, err = file.Stat()
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+}

--- a/lstater_test.go
+++ b/lstater_test.go
@@ -48,6 +48,9 @@ func TestLstatIfPossible(t *testing.T) {
 	roFs := &ReadOnlyFs{source: osFs}
 	roFsMem := &ReadOnlyFs{source: memFs}
 
+	if err := memFs.Mkdir(memWorkDir, 0700); err != nil {
+		t.Fatal(err)
+	}
 	pathFileMem := filepath.Join(memWorkDir, "aferom.txt")
 
 	WriteFile(osFs, filepath.Join(workDir, "afero.txt"), []byte("Hi, Afero!"), 0777)

--- a/memmap.go
+++ b/memmap.go
@@ -208,7 +208,7 @@ func (m *MemMapFs) findMissingDirs(path string) ([]string, error) {
 
 // Handle some relative paths
 func normalizePath(path string) string {
-	path = filepath.Clean(path)
+	path = filepath.Clean(FilePathSeparator + path) // prepend "/" to ensure "/tmp" and "tmp" are identical files
 
 	switch path {
 	case ".":

--- a/memmap.go
+++ b/memmap.go
@@ -208,7 +208,11 @@ func (m *MemMapFs) findMissingDirs(path string) ([]string, error) {
 
 // Handle some relative paths
 func normalizePath(path string) string {
-	path = filepath.Clean(FilePathSeparator + path) // prepend "/" to ensure "/tmp" and "tmp" are identical files
+	if !strings.HasPrefix(path, FilePathSeparator) {
+		path = filepath.Join(FilePathSeparator, path) // prepend "/" to ensure "/tmp" and "tmp" are identical files
+	} else {
+		path = filepath.Clean(path)
+	}
 
 	switch path {
 	case ".":

--- a/memmap_test.go
+++ b/memmap_test.go
@@ -35,7 +35,8 @@ func TestNormalizePath(t *testing.T) {
 
 func TestPathErrors(t *testing.T) {
 	path := filepath.Join(".", "some", "path")
-	path2 := filepath.Join(".", "different", "path")
+	path2 := filepath.Join(".", "different")
+	path3 := filepath.Join(".", "different", "long", "path")
 	fs := NewMemMapFs()
 	perm := os.FileMode(0755)
 
@@ -66,9 +67,9 @@ func TestPathErrors(t *testing.T) {
 	err = fs.Mkdir(path2, perm)
 	checkPathError(t, err, "Mkdir")
 
-	err = fs.MkdirAll(path2, perm)
+	err = fs.MkdirAll(path3, perm)
 	if err != nil {
-		t.Error("MkdirAll:", err)
+		t.Fatal(err)
 	}
 
 	_, err = fs.Open(path)
@@ -93,6 +94,7 @@ func TestPathErrors(t *testing.T) {
 }
 
 func checkPathError(t *testing.T, err error, op string) {
+	t.Helper()
 	pathErr, ok := err.(*os.PathError)
 	if !ok {
 		t.Error(op+":", err, "is not a os.PathError")

--- a/memmap_test.go
+++ b/memmap_test.go
@@ -489,7 +489,7 @@ func TestMemFsMkdirWithoutParent(t *testing.T) {
 	}
 
 	err = fs.Mkdir("/a/b", 0700)
-	if !os.IsPermission(err) {
+	if !IsNotDir(err) {
 		t.Error("Mkdir should fail if parent is not a directory:", err)
 	}
 }

--- a/memmap_test.go
+++ b/memmap_test.go
@@ -23,8 +23,8 @@ func TestNormalizePath(t *testing.T) {
 		{"../", FilePathSeparator},
 		{"./..", FilePathSeparator},
 		{"./../", FilePathSeparator},
-		{"tmp", "/tmp"}, // "tmp" and "/tmp" are equivalent in MemMapFS
-		{"/tmp", "/tmp"},
+		{"tmp", FilePathSeparator + "tmp"}, // "tmp" and "/tmp" are equivalent in MemMapFS
+		{FilePathSeparator + "tmp", FilePathSeparator + "tmp"},
 	}
 
 	for i, d := range data {

--- a/memmap_test.go
+++ b/memmap_test.go
@@ -472,3 +472,44 @@ func TestMemFsUnexpectedEOF(t *testing.T) {
 		t.Fatal("Expected ErrUnexpectedEOF")
 	}
 }
+
+// https://github.com/spf13/afero/issues/149
+func TestMemFsMkdirWithoutParent(t *testing.T) {
+	t.Parallel()
+
+	fs := NewMemMapFs()
+	err := fs.Mkdir("/a/b/c", 0700)
+	if !os.IsNotExist(err) {
+		t.Error("Mkdir should fail if parent directory does not exist:", err)
+	}
+
+	_, err = fs.Create("/a")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = fs.Mkdir("/a/b", 0700)
+	if !os.IsPermission(err) {
+		t.Error("Mkdir should fail if parent is not a directory:", err)
+	}
+}
+
+func TestMemFsCreateWithoutParent(t *testing.T) {
+	t.Parallel()
+
+	fs := NewMemMapFs()
+	_, err := fs.Create("/a/b/c")
+	if !os.IsNotExist(err) {
+		t.Error("Create should fail if parent directory does not exist:", err)
+	}
+
+	_, err = fs.Create("/a")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = fs.Create("/a/b")
+	if !IsNotDir(err) {
+		t.Error("Create should fail if parent is not a directory:", err)
+	}
+}

--- a/memmap_test.go
+++ b/memmap_test.go
@@ -23,6 +23,8 @@ func TestNormalizePath(t *testing.T) {
 		{"../", FilePathSeparator},
 		{"./..", FilePathSeparator},
 		{"./../", FilePathSeparator},
+		{"tmp", "/tmp"}, // "tmp" and "/tmp" are equivalent in MemMapFS
+		{"/tmp", "/tmp"},
 	}
 
 	for i, d := range data {


### PR DESCRIPTION
Fixes https://github.com/spf13/afero/issues/149 https://github.com/spf13/afero/issues/209

With this PR, now `MemMapFs` and `CopyOnWriteFs` only allow new files or directories if the parent exists and is a directory. Even though this is desirable (since it follows `OsFs` behavior), this likely breaks backward compatibility with v1 of afero. I had to fix several tests that relied on previous behavior.

@spf13 Is there a procedure on candidate PRs for afero@v2?

Also I'd be happy to squash related commits, if that makes it easier to review 😄 