### PR TITLE
Prevent MemMapFs.Chmod from changing all mode bits

### DIFF
--- a/memmap.go
+++ b/memmap.go
@@ -141,9 +141,7 @@ func (m *MemMapFs) Mkdir(name string, perm os.FileMode) error {
 	m.registerWithParent(item)
 	m.mu.Unlock()
 
-	m.Chmod(name, perm|os.ModeDir)
-
-	return nil
+	return m.unrestrictedChmod(name, perm|os.ModeDir)
 }
 
 func (m *MemMapFs) MkdirAll(path string, perm os.FileMode) error {
@@ -240,7 +238,7 @@ func (m *MemMapFs) OpenFile(name string, flag int, perm os.FileMode) (File, erro
 		}
 	}
 	if chmod {
-		m.Chmod(name, perm)
+		return file, m.unrestrictedChmod(name, perm)
 	}
 	return file, nil
 }
@@ -321,6 +319,22 @@ func (m *MemMapFs) Stat(name string) (os.FileInfo, error) {
 }
 
 func (m *MemMapFs) Chmod(name string, mode os.FileMode) error {
+	const chmodBits = os.ModePerm | os.ModeSetuid | os.ModeSetgid | os.ModeSticky // Only a subset of bits are allowed to be changed. Documented under os.Chmod()
+	mode &= chmodBits
+
+	m.mu.RLock()
+	f, ok := m.getData()[name]
+	m.mu.RUnlock()
+	if !ok {
+		return &os.PathError{Op: "chmod", Path: name, Err: ErrFileNotFound}
+	}
+	prevOtherBits := mem.GetFileInfo(f).Mode() & ^chmodBits
+
+	mode = prevOtherBits | mode
+	return m.unrestrictedChmod(name, mode)
+}
+
+func (m *MemMapFs) unrestrictedChmod(name string, mode os.FileMode) error {
 	name = normalizePath(name)
 
 	m.mu.RLock()

--- a/memmap.go
+++ b/memmap.go
@@ -141,7 +141,7 @@ func (m *MemMapFs) Mkdir(name string, perm os.FileMode) error {
 	m.registerWithParent(item)
 	m.mu.Unlock()
 
-	return m.unrestrictedChmod(name, perm|os.ModeDir)
+	return m.setFileMode(name, perm|os.ModeDir)
 }
 
 func (m *MemMapFs) MkdirAll(path string, perm os.FileMode) error {
@@ -238,7 +238,7 @@ func (m *MemMapFs) OpenFile(name string, flag int, perm os.FileMode) (File, erro
 		}
 	}
 	if chmod {
-		return file, m.unrestrictedChmod(name, perm)
+		return file, m.setFileMode(name, perm)
 	}
 	return file, nil
 }
@@ -331,10 +331,10 @@ func (m *MemMapFs) Chmod(name string, mode os.FileMode) error {
 	prevOtherBits := mem.GetFileInfo(f).Mode() & ^chmodBits
 
 	mode = prevOtherBits | mode
-	return m.unrestrictedChmod(name, mode)
+	return m.setFileMode(name, mode)
 }
 
-func (m *MemMapFs) unrestrictedChmod(name string, mode os.FileMode) error {
+func (m *MemMapFs) setFileMode(name string, mode os.FileMode) error {
 	name = normalizePath(name)
 
 	m.mu.RLock()

--- a/memmap_test.go
+++ b/memmap_test.go
@@ -477,7 +477,7 @@ func TestMemFsChmod(t *testing.T) {
 	t.Parallel()
 
 	fs := NewMemMapFs()
-	const file = "/hello"
+	const file = "hello"
 	if err := fs.Mkdir(file, 0700); err != nil {
 		t.Fatal(err)
 	}

--- a/memmap_test.go
+++ b/memmap_test.go
@@ -472,3 +472,34 @@ func TestMemFsUnexpectedEOF(t *testing.T) {
 		t.Fatal("Expected ErrUnexpectedEOF")
 	}
 }
+
+func TestMemFsChmod(t *testing.T) {
+	t.Parallel()
+
+	fs := NewMemMapFs()
+	const file = "/hello"
+	if err := fs.Mkdir(file, 0700); err != nil {
+		t.Fatal(err)
+	}
+
+	info, err := fs.Stat(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().String() != "drwx------" {
+		t.Fatal("mkdir failed to create a directory: mode =", info.Mode())
+	}
+
+	err = fs.Chmod(file, 0)
+	if err != nil {
+		t.Error("Failed to run chmod:", err)
+	}
+
+	info, err = fs.Stat(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().String() != "d---------" {
+		t.Error("chmod should not change file type. New mode =", info.Mode())
+	}
+}


### PR DESCRIPTION
I ran into an issue where my program called `fs.Chmod` and it changed from a directory to a regular file. This one had me stumped for weeks 😅 

After checking [`os.Chmod`'s docs](https://golang.org/pkg/os/#Chmod), I bit-masked the part Chmod is permitted to set, then OR'd it with the file's other previous mode bits. I also added a test to check the file type after setting all permission bits to 0.