### PR TITLE
Make MemMapFs implement Lstater

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,7 @@ module github.com/spf13/afero
 
 require (
 	github.com/pkg/sftp v1.10.1
+	github.com/stretchr/testify v1.4.0
 	golang.org/x/crypto v0.0.0-20190820162420-60c769a6c586
 	golang.org/x/text v0.3.3
 )

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,6 @@ module github.com/spf13/afero
 
 require (
 	github.com/pkg/sftp v1.10.1
-	github.com/stretchr/testify v1.4.0
 	golang.org/x/crypto v0.0.0-20190820162420-60c769a6c586
 	golang.org/x/text v0.3.3
 )

--- a/memmap.go
+++ b/memmap.go
@@ -317,6 +317,11 @@ func (m *MemMapFs) Rename(oldname, newname string) error {
 	return nil
 }
 
+func (m *MemMapFs) LstatIfPossible(name string) (os.FileInfo, bool, error) {
+	fileInfo, err := m.Stat(name)
+	return fileInfo, false, err
+}
+
 func (m *MemMapFs) Stat(name string) (os.FileInfo, error) {
 	f, err := m.Open(name)
 	if err != nil {

--- a/memmap_test.go
+++ b/memmap_test.go
@@ -8,9 +8,6 @@ import (
 	"runtime"
 	"testing"
 	"time"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestNormalizePath(t *testing.T) {
@@ -663,13 +660,21 @@ func TestMemFsLstatIfPossible(t *testing.T) {
 
 	// We assert that fs implements Lstater
 	fsAsserted, ok := fs.(Lstater)
-	require.True(t, ok, "The filesytem does not implement Lstater")
+	if !ok {
+		t.Fatalf("The filesytem does not implement Lstater")
+	}
 
 	file, err := fs.OpenFile("/a.txt", os.O_CREATE, 0o644)
-	require.NoError(t, err)
+	if err != nil {
+		t.Fatalf("Error when opening file: %v", err)
+	}
 	defer file.Close()
 
 	_, lstatCalled, err := fsAsserted.LstatIfPossible("/a.txt")
-	assert.NoError(t, err)
-	assert.False(t, lstatCalled)
+	if err != nil {
+		t.Fatalf("Function returned err: %v", err)
+	}
+	if lstatCalled {
+		t.Fatalf("Function indicated lstat was called. This should never be true.")
+	}
 }

--- a/memmap_test.go
+++ b/memmap_test.go
@@ -8,6 +8,9 @@ import (
 	"runtime"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNormalizePath(t *testing.T) {
@@ -649,4 +652,24 @@ func TestMemFsOpenFileModeIllegal(t *testing.T) {
 	if info.Mode() != os.FileMode(0644) {
 		t.Fatalf("should not be able to use OpenFile to set illegal mode: %s", info.Mode().String())
 	}
+}
+
+// LstatIfPossible should always return false, since MemMapFs does not
+// support symlinks.
+func TestMemFsLstatIfPossible(t *testing.T) {
+	t.Parallel()
+
+	fs := NewMemMapFs()
+
+	// We assert that fs implements Lstater
+	fsAsserted, ok := fs.(Lstater)
+	require.True(t, ok, "The filesytem does not implement Lstater")
+
+	file, err := fs.OpenFile("/a.txt", os.O_CREATE, 0o644)
+	require.NoError(t, err)
+	defer file.Close()
+
+	_, lstatCalled, err := fsAsserted.LstatIfPossible("/a.txt")
+	assert.NoError(t, err)
+	assert.False(t, lstatCalled)
 }


### PR DESCRIPTION
MemMapFs does not currently implement Lstater which can make it a bit difficult when a program is wanting to call Lstat on an unknown filesystem, so I am implementing the interface. The real call is to `Stat()`, and a `false` is simply returned to indicate that an Lstat was not called.

This change was prompted in my work of https://github.com/chigopher/pathlib, specifically: https://github.com/chigopher/pathlib/pull/16. The issue arose when testing a Walk function that calls LstatIfPossible, where the test uses a MemMapFs.