### PR TITLE
Do not panic on passing empty tar reader to tarfs

### DIFF
--- a/tarfs/fs.go
+++ b/tarfs/fs.go
@@ -63,6 +63,9 @@ func New(t *tar.Reader) *Fs {
 
 	}
 
+	if fs.files[afero.FilePathSeparator] == nil {
+		fs.files[afero.FilePathSeparator] = make(map[string]*File)
+	}
 	// Add a pseudoroot
 	fs.files[afero.FilePathSeparator][""] = &File{
 		h: &tar.Header{

--- a/tarfs/tarfs_test.go
+++ b/tarfs/tarfs_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"syscall"
 	"testing"
 
@@ -54,6 +55,9 @@ func TestMain(m *testing.M) {
 
 	tfs := New(tar.NewReader(tf))
 	afs = &afero.Afero{Fs: tfs}
+
+	// Check that an empty reader does not panic.
+	_ = New(tar.NewReader(strings.NewReader("")))
 	os.Exit(m.Run())
 }
 


### PR DESCRIPTION
Corrects a bug where passing an empty tar reader to tarfs would cause
adding the pseudoroot to panic with assignment to entry in nil map.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

cc @agimenez because it looked like you implemented tarfs (thank you for your work!)

@kargakis would it be possible to get a v1.4.1 published after merge?