### PR TITLE
Fix long relative path handling on windows

### DIFF
--- a/os.go
+++ b/os.go
@@ -34,7 +34,7 @@ func NewOsFs() Fs {
 func (OsFs) Name() string { return "OsFs" }
 
 func (OsFs) Create(name string) (File, error) {
-	f, e := os.Create(name)
+	f, e := os.Create(normalizeLongPath(name))
 	if f == nil {
 		// while this looks strange, we need to return a bare nil (of type nil) not
 		// a nil value of type *os.File or nil won't be nil
@@ -44,15 +44,15 @@ func (OsFs) Create(name string) (File, error) {
 }
 
 func (OsFs) Mkdir(name string, perm os.FileMode) error {
-	return os.Mkdir(name, perm)
+	return os.Mkdir(normalizeLongPath(name), perm)
 }
 
 func (OsFs) MkdirAll(path string, perm os.FileMode) error {
-	return os.MkdirAll(path, perm)
+	return os.MkdirAll(normalizeLongPath(path), perm)
 }
 
 func (OsFs) Open(name string) (File, error) {
-	f, e := os.Open(name)
+	f, e := os.Open(normalizeLongPath(name))
 	if f == nil {
 		// while this looks strange, we need to return a bare nil (of type nil) not
 		// a nil value of type *os.File or nil won't be nil
@@ -62,7 +62,7 @@ func (OsFs) Open(name string) (File, error) {
 }
 
 func (OsFs) OpenFile(name string, flag int, perm os.FileMode) (File, error) {
-	f, e := os.OpenFile(name, flag, perm)
+	f, e := os.OpenFile(normalizeLongPath(name), flag, perm)
 	if f == nil {
 		// while this looks strange, we need to return a bare nil (of type nil) not
 		// a nil value of type *os.File or nil won't be nil
@@ -72,35 +72,35 @@ func (OsFs) OpenFile(name string, flag int, perm os.FileMode) (File, error) {
 }
 
 func (OsFs) Remove(name string) error {
-	return os.Remove(name)
+	return os.Remove(normalizeLongPath(name))
 }
 
 func (OsFs) RemoveAll(path string) error {
-	return os.RemoveAll(path)
+	return os.RemoveAll(normalizeLongPath(path))
 }
 
 func (OsFs) Rename(oldname, newname string) error {
-	return os.Rename(oldname, newname)
+	return os.Rename(normalizeLongPath(oldname), normalizeLongPath(newname))
 }
 
 func (OsFs) Stat(name string) (os.FileInfo, error) {
-	return os.Stat(name)
+	return os.Stat(normalizeLongPath(name))
 }
 
 func (OsFs) Chmod(name string, mode os.FileMode) error {
-	return os.Chmod(name, mode)
+	return os.Chmod(normalizeLongPath(name), mode)
 }
 
 func (OsFs) Chown(name string, uid, gid int) error {
-	return os.Chown(name, uid, gid)
+	return os.Chown(normalizeLongPath(name), uid, gid)
 }
 
 func (OsFs) Chtimes(name string, atime time.Time, mtime time.Time) error {
-	return os.Chtimes(name, atime, mtime)
+	return os.Chtimes(normalizeLongPath(name), atime, mtime)
 }
 
 func (OsFs) LstatIfPossible(name string) (os.FileInfo, bool, error) {
-	fi, err := os.Lstat(name)
+	fi, err := os.Lstat(normalizeLongPath(name))
 	return fi, true, err
 }
 

--- a/os_stubs.go
+++ b/os_stubs.go
@@ -1,0 +1,8 @@
+// +build !windows
+
+package afero
+
+// implementing normalizeLongPath as stub prevents too much duplicated code in os_windows.go
+func normalizeLongPath(path string) string {
+	return path
+}

--- a/os_windows.go
+++ b/os_windows.go
@@ -1,0 +1,32 @@
+// +build windows
+
+package afero
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// windows cannot handle long relative paths, so convert to absolute paths by default
+func fixLongPath(path string) string {
+	// get absolute path - len(path) is not reliable for early return
+	absolutePath, err := filepath.Abs(path)
+
+	// fallback to default behaviour on error
+	if err != nil {
+		return path
+	}
+
+	// path is already normalized
+	if strings.HasPrefix(absolutePath, `\\?\`) {
+		return absolutePath
+	}
+
+	// normalize "network path"
+	if strings.HasPrefix(absolutePath, `\\`) {
+		return `\\?\UNC\` + strings.TrimPrefix(absolutePath, `\\`)
+	}
+
+	// normalize "local path"
+	return `\\?\` + absolutePath
+}

--- a/os_windows.go
+++ b/os_windows.go
@@ -8,7 +8,7 @@ import (
 )
 
 // windows cannot handle long relative paths, so convert to absolute paths by default
-func fixLongPath(path string) string {
+func normalizeLongPath(path string) string {
 	// get absolute path - len(path) is not reliable for early return
 	absolutePath, err := filepath.Abs(path)
 


### PR DESCRIPTION
On windows long relative paths led to an error (see https://github.com/golang/go/issues/21782). Here is a code example that fails (only on windows, on play it works): https://play.golang.org/p/wMS5gti4SD

To reproduce it you may use this on windows 10:

```
mkdir C:\inetpub\wwwroot\something_4.0\node_modules\babel-preset-es2015\node_modules\babel-plugin-transform-es2015-block-scoping\node_modules\babel-traverse\node_modules\babel-code-frame\node_modules\chalk\node_modules\strip-ansi\node_modules\ansi-regex\
echo "" > C:\inetpub\wwwroot\something_4.0\node_modules\babel-preset-es2015\node_modules\babel-plugin-transform-es2015-block-scoping\node_modules\babel-traverse\node_modules\babel-code-frame\node_modules\chalk\node_modules\strip-ansi\node_modules\ansi-regex\test.txt
```

And then use the `afero.Walk` on `C:\inetpub\wwwroot\something_4.0\` with a relative path traversal (e.g. `.` or `node_modules`).


Other projects solve this problem in a similar way:
- `rclone`: https://github.com/rclone/rclone/blob/9e2fbe0f1a9314e1330b4adc9d69de137be12ee6/lib/file/unc_windows.go#L16
- `restic`: https://github.com/restic/restic/blob/74c0607c9222edec3b0c140bb6fee962d6d2e82d/internal/fs/file_windows.go#L12

