### PR TITLE
Enable afero to be used on zos

### DIFF
--- a/const_bsds.go
+++ b/const_bsds.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build aix darwin openbsd freebsd netbsd dragonfly
+// +build aix darwin openbsd freebsd netbsd dragonfly zos
 
 package afero
 

--- a/const_win_unix.go
+++ b/const_win_unix.go
@@ -16,6 +16,7 @@
 // +build !dragonfly
 // +build !netbsd
 // +build !aix
+// +build !zos
 
 package afero
 

--- a/sftpfs/file.go
+++ b/sftpfs/file.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build !zos
+
 package sftpfs
 
 import (

--- a/sftpfs/sftp.go
+++ b/sftpfs/sftp.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build !zos
+
 package sftpfs
 
 import (

--- a/sftpfs/sftp_test.go
+++ b/sftpfs/sftp_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build !zos
+
 package sftpfs
 
 import (


### PR DESCRIPTION
Hello, Id like to contribute changes that enable afero to be used for go applications running on the zos operating system.  The changes are all build tag related.

There are two commits:
The first of these adds build tags to `const_bsds.go` and `const_win_unix.go` to enable afero to compile on zos.
The second of these disables build of the `sftpfs` package files for zos.  This is because github.com/pkg/sftp does not yet run on zos and this was causing unit test failures in afero. 

I have run the unit tests on zos
```
:>go version
go version go1.16.5 zos/s390x
:>go clean --cache --modcache --testcache
:>go test ./...
go: downloading golang.org/x/text v0.3.3
ok  	github.com/spf13/afero	5.238s
ok  	github.com/spf13/afero/mem	0.357s
ok  	github.com/spf13/afero/tarfs	0.135s
ok  	github.com/spf13/afero/zipfs	0.140s
```
I've also run the unit tests on my Mac and they all pass
```
afero % go clean --cache --modcache --testcache
afero % go test ./...
go: downloading github.com/pkg/sftp v1.10.1
go: downloading golang.org/x/text v0.3.3
go: downloading golang.org/x/crypto v0.0.0-20190820162420-60c769a6c586
go: downloading github.com/pkg/errors v0.8.1
go: downloading github.com/kr/fs v0.1.0
ok  	github.com/spf13/afero	5.306s
ok  	github.com/spf13/afero/mem	0.582s
ok  	github.com/spf13/afero/sftpfs	6.445s
ok  	github.com/spf13/afero/tarfs	0.850s
ok  	github.com/spf13/afero/zipfs	0.503s
```