### PR TITLE
regexpfs: always use file name instead of path

### DIFF
--- a/regexpfs.go
+++ b/regexpfs.go
@@ -2,6 +2,7 @@ package afero
 
 import (
 	"os"
+	"path/filepath"
 	"regexp"
 	"syscall"
 	"time"
@@ -29,7 +30,7 @@ func (r *RegexpFs) matchesName(name string) error {
 	if r.re == nil {
 		return nil
 	}
-	if r.re.MatchString(name) {
+	if r.re.MatchString(filepath.Base(name)) {
 		return nil
 	}
 	return syscall.ENOENT

--- a/ro_regexp_test.go
+++ b/ro_regexp_test.go
@@ -94,3 +94,21 @@ func TestFilterRegexReadDir(t *testing.T) {
 		t.Errorf("Got wrong number of names: %v", names)
 	}
 }
+
+func TestFilterRegexTarget(t *testing.T) {
+	mfs := &MemMapFs{}
+	fs := &RegexpFs{re: regexp.MustCompile(`^a`), source: mfs}
+
+	mfs.MkdirAll("/dir/", 0777)
+
+	_, err := fs.Create("a.txt")
+	if err != nil {
+		t.Errorf("Got unexpected error: %#err", err)
+	}
+
+	// regexp is applied with file name (not file path)
+	_, err = fs.Create("/dir/a.txt")
+	if err != nil {
+		t.Errorf("Got unexpected error: %#err", err)
+	}
+}


### PR DESCRIPTION
On `RegexpFs`, some operations apply given regexps with not file **name** but file **path**.
Fix this.

README
> A filtered view on file *names*, any file NOT matching the passed regexp will be treated as non-existing.
