### PR TITLE
(GH-319) `MemMapFs.Rename` will throw when destination exists

### DIFF
--- a/afero_test.go
+++ b/afero_test.go
@@ -193,15 +193,7 @@ func TestRename(t *testing.T) {
 		tDir := testDir(fs)
 		from := filepath.Join(tDir, "/renamefrom")
 		to := filepath.Join(tDir, "/renameto")
-		exists := filepath.Join(tDir, "/renameexists")
 		file, err := fs.Create(from)
-		if err != nil {
-			t.Fatalf("%s: open %q failed: %v", fs.Name(), to, err)
-		}
-		if err = file.Close(); err != nil {
-			t.Errorf("%s: close %q failed: %v", fs.Name(), to, err)
-		}
-		file, err = fs.Create(exists)
 		if err != nil {
 			t.Fatalf("%s: open %q failed: %v", fs.Name(), to, err)
 		}
@@ -211,17 +203,6 @@ func TestRename(t *testing.T) {
 		err = fs.Rename(from, to)
 		if err != nil {
 			t.Fatalf("%s: rename %q, %q failed: %v", fs.Name(), to, from, err)
-		}
-		file, err = fs.Create(from)
-		if err != nil {
-			t.Fatalf("%s: open %q failed: %v", fs.Name(), to, err)
-		}
-		if err = file.Close(); err != nil {
-			t.Errorf("%s: close %q failed: %v", fs.Name(), to, err)
-		}
-		err = fs.Rename(from, exists)
-		if err != nil {
-			t.Errorf("%s: rename %q, %q failed: %v", fs.Name(), exists, from, err)
 		}
 		names, err := readDirNames(fs, tDir)
 		if err != nil {

--- a/memmap.go
+++ b/memmap.go
@@ -300,6 +300,11 @@ func (m *MemMapFs) Rename(oldname, newname string) error {
 
 	m.mu.RLock()
 	defer m.mu.RUnlock()
+
+	if _, ok := m.getData()[newname]; ok {
+		return &os.PathError{Op: "rename", Path: newname, Err: ErrDestinationExists}
+	}
+
 	if _, ok := m.getData()[oldname]; ok {
 		m.mu.RUnlock()
 		m.mu.Lock()

--- a/memmap_test.go
+++ b/memmap_test.go
@@ -683,3 +683,26 @@ func TestMemFsLstatIfPossible(t *testing.T) {
 		t.Fatalf("Function indicated lstat was called. This should never be true.")
 	}
 }
+
+func TestMemFsRenameExistingDir(t *testing.T) {
+	testDirs := []string {
+		"/src/subdir1/",
+		"/src/subdir2/",
+	}
+
+	fs := NewMemMapFs()
+
+	for _, path := range testDirs {
+		err := fs.Mkdir(path, 0777)
+		if err != nil {
+			t.Error(err)
+		}
+	}
+
+	err := fs.Rename(testDirs[0], testDirs[1])
+	if err == nil {
+		t.Errorf("Rename should fail, directory already exists: %s", err)
+	} else if !os.IsExist(err) {
+		t.Errorf("Rename failed with unexpected error: %v", err)
+	}
+}


### PR DESCRIPTION
This commit ensures that MemMapFs behaves like os.Rename and throws an os.ErrExist if the destination path already exists.
