### PR TITLE
Call `OpenFile` instead of `Open` in `CacheOnReadFs` (fixes #193)

### DIFF
--- a/cacheOnReadFs.go
+++ b/cacheOnReadFs.go
@@ -75,6 +75,10 @@ func (u *CacheOnReadFs) copyToLayer(name string) error {
 	return copyToLayer(u.base, u.layer, name)
 }
 
+func (u *CacheOnReadFs) copyFileToLayer(name string, flag int, perm os.FileMode) error {
+	return copyFileToLayer(u.base, u.layer, name, flag, perm)
+}
+
 func (u *CacheOnReadFs) Chtimes(name string, atime, mtime time.Time) error {
 	st, _, err := u.cacheStatus(name)
 	if err != nil {
@@ -212,7 +216,7 @@ func (u *CacheOnReadFs) OpenFile(name string, flag int, perm os.FileMode) (File,
 	switch st {
 	case cacheLocal, cacheHit:
 	default:
-		if err := u.copyToLayer(name); err != nil {
+		if err := u.copyFileToLayer(name, flag, perm); err != nil {
 			return nil, err
 		}
 	}

--- a/unionFile.go
+++ b/unionFile.go
@@ -268,13 +268,7 @@ func (f *UnionFile) WriteString(s string) (n int, err error) {
 	return 0, BADFD
 }
 
-func copyToLayer(base Fs, layer Fs, name string) error {
-	bfh, err := base.Open(name)
-	if err != nil {
-		return err
-	}
-	defer bfh.Close()
-
+func copyFile(base Fs, layer Fs, name string, bfh File) error {
 	// First make sure the directory exists
 	exists, err := Exists(layer, filepath.Dir(name))
 	if err != nil {
@@ -314,4 +308,24 @@ func copyToLayer(base Fs, layer Fs, name string) error {
 		return err
 	}
 	return layer.Chtimes(name, bfi.ModTime(), bfi.ModTime())
+}
+
+func copyToLayer(base Fs, layer Fs, name string) error {
+	bfh, err := base.Open(name)
+	if err != nil {
+		return err
+	}
+	defer bfh.Close()
+
+	return copyFile(base, layer, name, bfh)
+}
+
+func copyFileToLayer(base Fs, layer Fs, name string, flag int, perm os.FileMode) error {
+	bfh, err := base.OpenFile(name, flag, perm)
+	if err != nil {
+		return err
+	}
+	defer bfh.Close()
+
+	return copyFile(base, layer, name, bfh)
 }


### PR DESCRIPTION
This closes #193 by calling `OpenFile` instead of `Open` when appropiate, thus passing i.e. `O_CREATE` to the layer. Already tested in https://github.com/pojntfx/stfs.