### PR TITLE
add modTime on folder creation

### DIFF
--- a/mem/file.go
+++ b/mem/file.go
@@ -71,7 +71,7 @@ func CreateFile(name string) *FileData {
 }
 
 func CreateDir(name string) *FileData {
-	return &FileData{name: name, memDir: &DirMap{}, dir: true}
+	return &FileData{name: name, memDir: &DirMap{}, dir: true, modtime: time.Now()}
 }
 
 func ChangeFileName(f *FileData, newname string) {

--- a/memmap_test.go
+++ b/memmap_test.go
@@ -451,7 +451,7 @@ func TestMemFsMkdirAllMode(t *testing.T) {
 		t.Error("/a: mode is not directory")
 	}
 	if !info.ModTime().After(time.Now().Add(-1 * time.Hour)) {
-		t.Errorf("/a: mod time not set, got %s", info.Mode())
+		t.Errorf("/a: mod time not set, got %s", info.ModTime())
 	}
 	if info.Mode() != os.FileMode(os.ModeDir|0755) {
 		t.Errorf("/a: wrong permissions, expected drwxr-xr-x, got %s", info.Mode())
@@ -467,7 +467,7 @@ func TestMemFsMkdirAllMode(t *testing.T) {
 		t.Errorf("/a/b: wrong permissions, expected drwxr-xr-x, got %s", info.Mode())
 	}
 	if !info.ModTime().After(time.Now().Add(-1 * time.Hour)) {
-		t.Errorf("/a/b: mod time not set, got %s", info.Mode())
+		t.Errorf("/a/b: mod time not set, got %s", info.ModTime())
 	}
 	info, err = fs.Stat("/a/b/c")
 	if err != nil {
@@ -480,7 +480,7 @@ func TestMemFsMkdirAllMode(t *testing.T) {
 		t.Errorf("/a/b/c: wrong permissions, expected drwxr-xr-x, got %s", info.Mode())
 	}
 	if !info.ModTime().After(time.Now().Add(-1 * time.Hour)) {
-		t.Errorf("/a/b/c: mod time not set, got %s", info.Mode())
+		t.Errorf("/a/b/c: mod time not set, got %s", info.ModTime())
 	}
 }
 

--- a/memmap_test.go
+++ b/memmap_test.go
@@ -450,6 +450,9 @@ func TestMemFsMkdirAllMode(t *testing.T) {
 	if !info.Mode().IsDir() {
 		t.Error("/a: mode is not directory")
 	}
+	if !info.ModTime().After(time.Now().Add(-1 * time.Hour)) {
+		t.Errorf("/a: mod time not set, got %s", info.Mode())
+	}
 	if info.Mode() != os.FileMode(os.ModeDir|0755) {
 		t.Errorf("/a: wrong permissions, expected drwxr-xr-x, got %s", info.Mode())
 	}
@@ -463,6 +466,9 @@ func TestMemFsMkdirAllMode(t *testing.T) {
 	if info.Mode() != os.FileMode(os.ModeDir|0755) {
 		t.Errorf("/a/b: wrong permissions, expected drwxr-xr-x, got %s", info.Mode())
 	}
+	if !info.ModTime().After(time.Now().Add(-1 * time.Hour)) {
+		t.Errorf("/a/b: mod time not set, got %s", info.Mode())
+	}
 	info, err = fs.Stat("/a/b/c")
 	if err != nil {
 		t.Fatal(err)
@@ -472,6 +478,9 @@ func TestMemFsMkdirAllMode(t *testing.T) {
 	}
 	if info.Mode() != os.FileMode(os.ModeDir|0755) {
 		t.Errorf("/a/b/c: wrong permissions, expected drwxr-xr-x, got %s", info.Mode())
+	}
+	if !info.ModTime().After(time.Now().Add(-1 * time.Hour)) {
+		t.Errorf("/a/b/c: mod time not set, got %s", info.Mode())
 	}
 }
 


### PR DESCRIPTION
`NewOsFs` behaviour for `CreateDir` includes modTime on both Mac + Linux. 
`NewOsFs` behaviour for renaming directories does not update modTime.

This makes `NewMemMapFs` have the same behaviour rather than a time of `0001-01-01 00:00:00 +0000 UTC`