### PR TITLE
Fix gcsfs RemoveAll

### DIFF
--- a/gcsfs/file.go
+++ b/gcsfs/file.go
@@ -109,7 +109,7 @@ func (o *GcsFile) Seek(newOffset int64, whence int) (int64, error) {
 	if (whence == 0 && newOffset == o.fhOffset) || (whence == 1 && newOffset == 0) {
 		return o.fhOffset, nil
 	}
-	log.Printf("WARNING: Seek beavhior triggered, highly inefficent. Offset before seek is at %d\n", o.fhOffset)
+	log.Printf("WARNING: Seek behavior triggered, highly inefficent. Offset before seek is at %d\n", o.fhOffset)
 
 	//Fore the reader/writers to be reopened (at correct offset)
 	err := o.Sync()

--- a/gcsfs/fs.go
+++ b/gcsfs/fs.go
@@ -325,9 +325,14 @@ func (fs *Fs) RemoveAll(path string) error {
 	}
 
 	pathInfo, err := fs.Stat(path)
+	if errors.Is(err, ErrFileNotFound) {
+		// return early if file doesn't exist
+		return nil
+	}
 	if err != nil {
 		return err
 	}
+
 	if !pathInfo.IsDir() {
 		return fs.Remove(path)
 	}

--- a/gcsfs/gcs_test.go
+++ b/gcsfs/gcs_test.go
@@ -809,7 +809,7 @@ func TestGcsRemoveAll(t *testing.T) {
 	t.Run("non-existent", func(t *testing.T) {
 		err := gcsAfs.RemoveAll(filepath.Join(bucketName, "a"))
 		if err != nil {
-			t.Fatal("failed when removing non-existent file")
+			t.Fatal("error should be nil when removing non-existent file")
 		}
 	})
 	t.Run("success", func(t *testing.T) {

--- a/gcsfs/gcs_test.go
+++ b/gcsfs/gcs_test.go
@@ -804,3 +804,35 @@ func TestGcsMkdirAll(t *testing.T) {
 		}
 	})
 }
+
+func TestGcsRemoveAll(t *testing.T) {
+	t.Run("non-existent", func(t *testing.T) {
+		err := gcsAfs.RemoveAll(filepath.Join(bucketName, "a"))
+		if err != nil {
+			t.Fatal("failed when removing non-existent file")
+		}
+	})
+	t.Run("success", func(t *testing.T) {
+		aDir := filepath.Join(bucketName, "a")
+		bDir := filepath.Join(aDir, "b")
+
+		err := gcsAfs.MkdirAll(bDir, 0755)
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, err = gcsAfs.Stat(bDir)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = gcsAfs.RemoveAll(aDir)
+		if err != nil {
+			t.Fatalf("failed to remove the folder %s with error: %s", aDir, err)
+		}
+
+		_, err = gcsAfs.Stat(aDir)
+		if err == nil {
+			t.Fatalf("folder %s wasn't removed", aDir)
+		}
+	})
+}


### PR DESCRIPTION
`RemoveAll` in `gcsfs` returns an error when the file/directory to be removed doesn't exist. It should return nil in this case.