### PR TITLE
mem: add rudimentary (*FileInfo).Sys() method

### DIFF
--- a/mem/file.go
+++ b/mem/file.go
@@ -353,7 +353,7 @@ func (s *FileInfo) IsDir() bool {
 	defer s.Unlock()
 	return s.dir
 }
-func (s *FileInfo) Sys() interface{} { return nil }
+
 func (s *FileInfo) Size() int64 {
 	if s.IsDir() {
 		return int64(42)
@@ -361,6 +361,12 @@ func (s *FileInfo) Size() int64 {
 	s.Lock()
 	defer s.Unlock()
 	return int64(len(s.data))
+}
+
+func (s *FileInfo) Sys() interface{} {
+	s.Lock()
+	defer s.Unlock()
+	return sysFromFileInfo(s)
 }
 
 var (

--- a/mem/file_other.go
+++ b/mem/file_other.go
@@ -1,0 +1,20 @@
+// Copyright © 2015 Steve Francia <spf@spf13.com>.
+// Copyright 2013 tsuru authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build windows || wasm
+// +build windows wasm
+
+package mem
+
+func sysFromFileInfo(s *FileInfo) interface{} { return nil }

--- a/mem/file_unix.go
+++ b/mem/file_unix.go
@@ -1,0 +1,32 @@
+// Copyright © 2015 Steve Francia <spf@spf13.com>.
+// Copyright 2013 tsuru authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !(windows || wasm)
+// +build !windows,!wasm
+
+package mem
+
+import "syscall"
+
+func sysFromFileInfo(s *FileInfo) interface{} {
+	sys := &syscall.Stat_t{
+		Uid:  uint32(s.uid),
+		Gid:  uint32(s.gid),
+		Size: 42,
+	}
+	if !s.dir {
+		sys.Size = int64(len(s.data))
+	}
+	return sys
+}


### PR DESCRIPTION
This allows downstream users to act on file ownership.

(A previous version added `mem.GetUID()`/`mem.GetGID()` methods, which didn't prove fruitful.)