### PR TITLE
Fixes io.ReaderAt implementation of mem.File

### DIFF
--- a/iofs_test.go
+++ b/iofs_test.go
@@ -40,7 +40,15 @@ func TestIOFS(t *testing.T) {
 			t.Fatal("OpenFile (O_CREATE) failed:", err)
 		}
 
-		f.Close()
+		_, err = f.WriteString("a")
+		if err != nil {
+			t.Fatal("WriteString failed:", err)
+		}
+
+		err = f.Close()
+		if err != nil {
+			t.Fatal("Close failed:", err)
+		}
 
 		if err := fstest.TestFS(NewIOFS(mmfs), "dir1/dir2/test.txt"); err != nil {
 			t.Error(err)

--- a/mem/file.go
+++ b/mem/file.go
@@ -223,6 +223,9 @@ func (f *File) ReadAt(b []byte, off int64) (n int, err error) {
 		n = len(f.fileData.data) - int(off)
 	}
 	copy(b, f.fileData.data[off:off+int64(n)])
+	if n < len(b) {
+		err = io.EOF
+	}
 	return
 }
 
@@ -231,7 +234,6 @@ func (f *File) Read(b []byte) (n int, err error) {
 	atomic.AddInt64(&f.at, int64(n))
 	return
 }
-
 func (f *File) Truncate(size int64) error {
 	if f.closed {
 		return ErrFileClosed

--- a/mem/file.go
+++ b/mem/file.go
@@ -232,6 +232,9 @@ func (f *File) ReadAt(b []byte, off int64) (n int, err error) {
 func (f *File) Read(b []byte) (n int, err error) {
 	n, err = f.ReadAt(b, atomic.LoadInt64(&f.at))
 	atomic.AddInt64(&f.at, int64(n))
+	if n > 0 && err == io.EOF {
+		err = nil
+	}
 	return
 }
 func (f *File) Truncate(size int64) error {

--- a/mem/file_test.go
+++ b/mem/file_test.go
@@ -232,9 +232,20 @@ func TestFileReadAtSeekOffset(t *testing.T) {
 		t.Fatal("expected 0")
 	}
 
-	b := make([]byte, 4)
+	b := make([]byte, 4, 5)
 	n, err := f.ReadAt(b, 0)
 	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 4 {
+		t.Fail()
+	}
+	if string(b) != "TEST" {
+		t.Fail()
+	}
+
+	n, err = f.ReadAt(b[:cap(b)], 0)
+	if err != io.EOF {
 		t.Fatal(err)
 	}
 	if n != 4 {


### PR DESCRIPTION
Adds tests:
- `*mem.File` implementation of `io.ReaderAt` must return non-nil error when reading less than length of give slice.
- `MemMapFs` must pass `fstest.TestFS` tests for non-empty files.

Fixes #352 .