### PR TITLE
Make IOFS.ReadDir check for fs.ReadDirFile

### DIFF
--- a/iofs.go
+++ b/iofs.go
@@ -8,6 +8,7 @@ import (
 	"io/fs"
 	"os"
 	"path"
+	"sort"
 	"time"
 )
 
@@ -67,10 +68,22 @@ func (iofs IOFS) Glob(pattern string) ([]string, error) {
 }
 
 func (iofs IOFS) ReadDir(name string) ([]fs.DirEntry, error) {
-	items, err := ReadDir(iofs.Fs, name)
+	f, err := iofs.Fs.Open(name)
 	if err != nil {
 		return nil, iofs.wrapError("readdir", name, err)
 	}
+
+	defer f.Close()
+
+	if rdf, ok := f.(fs.ReadDirFile); ok {
+		return rdf.ReadDir(-1)
+	}
+
+	items, err := f.Readdir(-1)
+	if err != nil {
+		return nil, iofs.wrapError("readdir", name, err)
+	}
+	sort.Sort(byName(items))
 
 	ret := make([]fs.DirEntry, len(items))
 	for i := range items {


### PR DESCRIPTION
And implement `fs.ReadDirFile` for `BasePathFile`.

There are other `File` implementations that could also benefit from the above, but
this is a start.

The primary motivation behind this is to allow `fs.WalkDir` use the native
implementation whenever possible, as that new function was added in Go 1.16 with
speed as its main selling point.

This commit also adds a benchmark for `fs.WalkDir` that, when compared to the main branch:

```bash
name        old time/op    new time/op    delta
WalkDir-10     369µs ± 1%     196µs ± 3%  -46.89%  (p=0.029 n=4+4)

name        old alloc/op   new alloc/op   delta
WalkDir-10    85.3kB ± 0%    40.2kB ± 0%  -52.87%  (p=0.029 n=4+4)

name        old allocs/op  new allocs/op  delta
WalkDir-10       826 ± 0%       584 ± 0%  -29.30%  (p=0.029 n=4+4)
```

Fixes #365
