### PR TITLE
Fix sorting in IOFS.ReadDir

### DIFF
--- a/iofs.go
+++ b/iofs.go
@@ -76,7 +76,12 @@ func (iofs IOFS) ReadDir(name string) ([]fs.DirEntry, error) {
 	defer f.Close()
 
 	if rdf, ok := f.(fs.ReadDirFile); ok {
-		return rdf.ReadDir(-1)
+		items, err := rdf.ReadDir(-1)
+		if err != nil {
+			return nil, iofs.wrapError("readdir", name, err)
+		}
+		sort.Slice(items, func(i, j int) bool { return items[i].Name() < items[j].Name() })
+		return items, nil
 	}
 
 	items, err := f.Readdir(-1)

--- a/ioutil.go
+++ b/ioutil.go
@@ -141,7 +141,7 @@ func WriteFile(fs Fs, filename string, data []byte, perm os.FileMode) error {
 // We generate random temporary file names so that there's a good
 // chance the file doesn't exist yet - keeps the number of tries in
 // TempFile to a minimum.
-var rand uint32
+var randNum uint32
 var randmu sync.Mutex
 
 func reseed() uint32 {
@@ -150,12 +150,12 @@ func reseed() uint32 {
 
 func nextRandom() string {
 	randmu.Lock()
-	r := rand
+	r := randNum
 	if r == 0 {
 		r = reseed()
 	}
 	r = r*1664525 + 1013904223 // constants from Numerical Recipes
-	rand = r
+	randNum = r
 	randmu.Unlock()
 	return strconv.Itoa(int(1e9 + r%1e9))[1:]
 }
@@ -194,7 +194,7 @@ func TempFile(fs Fs, dir, pattern string) (f File, err error) {
 		if os.IsExist(err) {
 			if nconflict++; nconflict > 10 {
 				randmu.Lock()
-				rand = reseed()
+				randNum = reseed()
 				randmu.Unlock()
 			}
 			continue
@@ -226,7 +226,7 @@ func TempDir(fs Fs, dir, prefix string) (name string, err error) {
 		if os.IsExist(err) {
 			if nconflict++; nconflict > 10 {
 				randmu.Lock()
-				rand = reseed()
+				randNum = reseed()
 				randmu.Unlock()
 			}
 			continue


### PR DESCRIPTION
We recently added a check for fs.ReadDirFile in IOFS.ReadDir, but forgot to apply a sort to the
result as defined in the spec.

This fixes that and adds a test case for it.
