### PR TITLE
Add sftpfs files ReadAt method

### DIFF
--- a/sftpfs/file.go
+++ b/sftpfs/file.go
@@ -64,9 +64,8 @@ func (f *File) Read(b []byte) (n int, err error) {
 	return f.fd.Read(b)
 }
 
-// TODO
 func (f *File) ReadAt(b []byte, off int64) (n int, err error) {
-	return 0, nil
+	return f.fd.ReadAt(b, off)
 }
 
 func (f *File) Readdir(count int) (res []os.FileInfo, err error) {


### PR DESCRIPTION
This method is still a TODO after 6 years despite being a simple delegate, i don't think i missed any real reason why it wasn't implemented but i could be wrong.