### PR TITLE
Fix concurrency issue in MemMapFs.Mkdir/MkdirAll

### DIFF
--- a/memmap.go
+++ b/memmap.go
@@ -142,6 +142,11 @@ func (m *MemMapFs) Mkdir(name string, perm os.FileMode) error {
 	}
 
 	m.mu.Lock()
+	// Dobule check that it doesn't exist.
+	if _, ok := m.getData()[name]; ok {
+		m.mu.Unlock()
+		return &os.PathError{Op: "mkdir", Path: name, Err: ErrFileExists}
+	}
 	item := mem.CreateDir(name)
 	mem.SetMode(item, os.ModeDir|perm)
 	m.getData()[name] = item


### PR DESCRIPTION
* The backing map is protected by a RWMutex
* This commit double checks for the existence of the directory inside the write lock to avoid potential data races when multiple goroutines tries to create
the same directory.

Fixes #361
Fixes #298
