### PR TITLE
Add build flags for z/OS Unix System Services

### DIFF
--- a/const_bsds.go
+++ b/const_bsds.go
@@ -11,8 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build aix || darwin || openbsd || freebsd || netbsd || dragonfly
-// +build aix darwin openbsd freebsd netbsd dragonfly
+//go:build aix || darwin || openbsd || freebsd || netbsd || dragonfly || zos
+// +build aix darwin openbsd freebsd netbsd dragonfly zos
 
 package afero
 

--- a/const_win_unix.go
+++ b/const_win_unix.go
@@ -10,8 +10,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//go:build !darwin && !openbsd && !freebsd && !dragonfly && !netbsd && !aix
-// +build !darwin,!openbsd,!freebsd,!dragonfly,!netbsd,!aix
+//go:build !darwin && !openbsd && !freebsd && !dragonfly && !netbsd && !aix && !zos
+// +build !darwin,!openbsd,!freebsd,!dragonfly,!netbsd,!aix,!zos
 
 package afero
 


### PR DESCRIPTION
Added flags to `const_bsds.go` and `const_win_unix.go` to allow for building on IBM z/OS Unix System Services.

Can now clone the afero repository on a z/OS USS shell and run `go install` with no issues.

Afero is a dependency for the k6 tool, and enabling these build flags allows k6 to be built and run on z/OS.