### PR TITLE
Fix MemMapFs inconsistent path store

### DIFF
--- a/memmap.go
+++ b/memmap.go
@@ -177,9 +177,13 @@ func normalizePath(path string) string {
 		return FilePathSeparator
 	case "..":
 		return FilePathSeparator
-	default:
-		return path
 	}
+
+	// If path isn't rooted make it rooted
+	if !strings.HasPrefix(path, FilePathSeparator) {
+		path = FilePathSeparator + path
+	}
+	return path
 }
 
 func (m *MemMapFs) Open(name string) (File, error) {
@@ -351,6 +355,7 @@ func (m *MemMapFs) Stat(name string) (os.FileInfo, error) {
 
 func (m *MemMapFs) Chmod(name string, mode os.FileMode) error {
 	mode &= chmodBits
+	name = normalizePath(name)
 
 	m.mu.RLock()
 	f, ok := m.getData()[name]


### PR DESCRIPTION
Adds a test that fails for the current MemMapFs when creating files in nested directories with synonyms for the path (i.e. full path, relative path, explict relative path).

Also fixes MemMapFs so that test (and all others pass).