### PR TITLE
Add check for path separator to TempDir

### DIFF
--- a/ioutil.go
+++ b/ioutil.go
@@ -17,6 +17,7 @@ package afero
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -218,6 +219,12 @@ func (a Afero) TempDir(dir, prefix string) (name string, err error) {
 }
 
 func TempDir(fs Fs, dir, prefix string) (name string, err error) {
+
+	if strings.Contains(prefix, string(os.PathSeparator)) {
+		err = fmt.Errorf("%s: pattern contains path separator", prefix)
+		return
+	}
+
 	if dir == "" {
 		dir = os.TempDir()
 	}

--- a/ioutil_test.go
+++ b/ioutil_test.go
@@ -17,6 +17,7 @@ package afero
 
 import (
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 )
@@ -171,6 +172,80 @@ func TestTempFile(t *testing.T) {
 				return
 			}
 			tt.want(t, filepath.Base(file.Name()))
+		})
+	}
+}
+
+func TestTempDir(t *testing.T) {
+
+	type testData struct {
+		dir            string
+		prefix         string
+		expectedPrefix string
+		shouldError    bool
+	}
+
+	tests := map[string]testData{
+		"TempDirWithStar": {
+			dir:            "",
+			prefix:         "withStar*",
+			expectedPrefix: "/tmp/withStar",
+		},
+		"TempDirWithTwoStars": {
+			dir:            "",
+			prefix:         "withStar**",
+			expectedPrefix: "/tmp/withStar*",
+		},
+		"TempDirWithoutStar": {
+			dir:            "",
+			prefix:         "withoutStar",
+			expectedPrefix: "/tmp/withoutStar",
+		},
+		"UserDir": {
+			dir:            "dir1",
+			prefix:         "",
+			expectedPrefix: "dir1/",
+		},
+		"InvalidPrefix": {
+			dir:            "",
+			prefix:         "hello/world",
+			expectedPrefix: "hello",
+			shouldError:    true,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			afs := NewMemMapFs()
+			result, err := TempDir(afs, test.dir, test.prefix)
+
+			if test.shouldError {
+				if err == nil {
+					t.Error("err should not be nil")
+					return
+				}
+				if result != "" {
+					t.Errorf("result was %s and should be the empty string", result)
+					return
+				}
+			} else {
+				match, _ := regexp.MatchString(test.expectedPrefix+".*", result)
+				if !match {
+					t.Errorf("directory should have prefix %s should exist, but doesn't", test.expectedPrefix)
+					return
+				}
+				exists, err := DirExists(afs, result)
+				if !exists {
+					t.Errorf("directory with prefix %s should exist, but doesn't", test.expectedPrefix)
+					return
+				}
+				if err != nil {
+					t.Errorf("err should be nil, but was %s", err.Error())
+					return
+				}
+			}
+
+			afs.RemoveAll(result)
 		})
 	}
 }


### PR DESCRIPTION
Since GO 1.17, ioutil.TempDir has called MkdirTemp for it's implementation. Since at least October of 2020, MkdirTemp has [checked the input prefix for os.PathSeparator](https://cs.opensource.google/go/go/+/refs/tags/go1.20.5:src/os/tempfile.go;l=62;bpv=0;bpt=0). This PR adds that check and returns an error in that case.

The PR also includes some basic tests for the TempDir function.