### PR TITLE
Add wasip1 build flags

### DIFF
--- a/const_bsds.go
+++ b/const_bsds.go
@@ -11,8 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build aix || darwin || openbsd || freebsd || netbsd || dragonfly || zos
-// +build aix darwin openbsd freebsd netbsd dragonfly zos
+//go:build aix || darwin || openbsd || freebsd || netbsd || dragonfly || zos || wasip1
+// +build aix darwin openbsd freebsd netbsd dragonfly zos wasip1
 
 package afero
 

--- a/const_win_unix.go
+++ b/const_win_unix.go
@@ -10,8 +10,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//go:build !darwin && !openbsd && !freebsd && !dragonfly && !netbsd && !aix && !zos
-// +build !darwin,!openbsd,!freebsd,!dragonfly,!netbsd,!aix,!zos
+//go:build !darwin && !openbsd && !freebsd && !dragonfly && !netbsd && !aix && !zos && !wasip1
+// +build !darwin,!openbsd,!freebsd,!dragonfly,!netbsd,!aix,!zos,!wasip1
 
 package afero
 


### PR DESCRIPTION
Added flags to `const_bsds.go` and `const_win_unix.go` to allow for building on WASIp1 (Go 1.21)

Closes #399
