### PR TITLE
Fix the infinite recursion with afero.Walk

### DIFF
--- a/afero_test.go
+++ b/afero_test.go
@@ -32,7 +32,7 @@ var (
 	Fss      = []Fs{&MemMapFs{}, &OsFs{}}
 )
 
-var testRegistry map[Fs][]string = make(map[Fs][]string)
+var testRegistry = make(map[Fs][]string)
 
 func testDir(fs Fs) string {
 	name, err := TempDir(fs, "", "afero")

--- a/path.go
+++ b/path.go
@@ -59,8 +59,8 @@ func walk(fs Fs, path string, info os.FileInfo, walkFn filepath.WalkFunc) error 
 	}
 
 	for _, name := range names {
-		if name == path {
-			// skip current directory to avoid infinite recursion
+		if name == "" {
+			// skip empty names to avoid infinite recursion
 			continue
 		}
 		filename := filepath.Join(path, name)

--- a/path.go
+++ b/path.go
@@ -59,6 +59,10 @@ func walk(fs Fs, path string, info os.FileInfo, walkFn filepath.WalkFunc) error 
 	}
 
 	for _, name := range names {
+		if name == path {
+			// skip current directory to avoid infinite recursion
+			continue
+		}
 		filename := filepath.Join(path, name)
 		fileInfo, err := lstatIfPossible(fs, filename)
 		if err != nil {

--- a/path_test.go
+++ b/path_test.go
@@ -67,3 +67,27 @@ func TestWalk(t *testing.T) {
 		t.Fail()
 	}
 }
+
+func TestWalkRemoveRoot(t *testing.T) {
+	defer removeAllTestFiles(t)
+	fs := Fss[0]
+	rootPath := "."
+
+	err := fs.RemoveAll(rootPath)
+	if err != nil {
+		t.Error(err)
+	}
+
+	testRegistry[fs] = append(testRegistry[fs], rootPath)
+	setupTestFiles(t, fs, rootPath)
+
+	walkFn := func(path string, info os.FileInfo, err error) error {
+		fmt.Println(path, info.Name(), info.IsDir(), info.Size(), err)
+		return err
+	}
+
+	err = Walk(fs, rootPath, walkFn)
+	if err != nil {
+		t.Error(err)
+	}
+}


### PR DESCRIPTION
This PR fixes https://github.com/spf13/afero/issues/185

Fix the infinite recursion by skipping the current directory in the directory names listing


