### PR TITLE
Fix O_EXCL without O_CREATE in memmap fs

### DIFF
--- a/memmap.go
+++ b/memmap.go
@@ -245,7 +245,7 @@ func (m *MemMapFs) OpenFile(name string, flag int, perm os.FileMode) (File, erro
 	perm &= chmodBits
 	chmod := false
 	file, err := m.openWrite(name)
-	if err == nil && (flag&os.O_EXCL > 0) {
+	if err == nil && (flag&(os.O_CREATE|os.O_EXCL)) == (os.O_CREATE|os.O_EXCL) {
 		return nil, &os.PathError{Op: "open", Path: name, Err: ErrFileExists}
 	}
 	if os.IsNotExist(err) && (flag&os.O_CREATE > 0) {

--- a/memmap_test.go
+++ b/memmap_test.go
@@ -918,3 +918,25 @@ func TestMemMapFsRename(t *testing.T) {
 		}
 	}
 }
+
+func TestMemMapCreateThenOpen(t *testing.T) {
+	fs := NewMemMapFs()
+	filePath := "/test/data.txt"
+	err := fs.MkdirAll("/test", 0744)
+	if err != nil {
+		t.Fatal(err)
+	}
+	f1, err := fs.OpenFile(filePath, os.O_CREATE|os.O_RDWR|os.O_EXCL, 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = f1.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+	f2, err := fs.OpenFile(filePath, os.O_RDWR|os.O_EXCL, 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	f2.Close()
+}


### PR DESCRIPTION
Fix issue where OpenFile fails incorrectly trying to open an existing file with O_EXCL in memmap fs.