### PR TITLE
Add buckets caching to GcsFS

### DIFF
--- a/gcsfs/fs.go
+++ b/gcsfs/fs.go
@@ -54,6 +54,7 @@ func NewGcsFsWithSeparator(ctx context.Context, client stiface.Client, folderSep
 		ctx:           ctx,
 		client:        client,
 		separator:     folderSep,
+		buckets:       make(map[string]stiface.BucketHandle),
 		rawGcsObjects: make(map[string]*GcsFile),
 
 		autoRemoveEmptyFolders: true,
@@ -109,6 +110,7 @@ func (fs *Fs) getBucket(name string) (stiface.BucketHandle, error) {
 		if err != nil {
 			return nil, err
 		}
+		fs.buckets[name] = bucket
 	}
 	return bucket, nil
 }


### PR DESCRIPTION
Without it each files interaction on GCS results in an unnecessary GetBucket request.