### PR TITLE
Add sftpfs files WriteAt and Sync methods

### DIFF
--- a/sftpfs/file.go
+++ b/sftpfs/file.go
@@ -100,9 +100,8 @@ func (f *File) Write(b []byte) (n int, err error) {
 	return f.fd.Write(b)
 }
 
-// TODO
 func (f *File) WriteAt(b []byte, off int64) (n int, err error) {
-	return 0, nil
+	return f.fd.WriteAt(b, off)
 }
 
 func (f *File) WriteString(s string) (ret int, err error) {

--- a/sftpfs/file.go
+++ b/sftpfs/file.go
@@ -64,9 +64,8 @@ func (f *File) Read(b []byte) (n int, err error) {
 	return f.fd.Read(b)
 }
 
-// TODO
 func (f *File) ReadAt(b []byte, off int64) (n int, err error) {
-	return 0, nil
+	return f.fd.ReadAt(b, off)
 }
 
 func (f *File) Readdir(count int) (res []os.FileInfo, err error) {

--- a/sftpfs/file.go
+++ b/sftpfs/file.go
@@ -53,7 +53,7 @@ func (f *File) Stat() (os.FileInfo, error) {
 }
 
 func (f *File) Sync() error {
-	return nil
+	return f.fd.Sync()
 }
 
 func (f *File) Truncate(size int64) error {


### PR DESCRIPTION
Similarly to #378 the WriteAt and Sync methods are also missing and a TODO despite being implemented by sftp.File already.

Also may i suggest just nesting sftp.File into sftpfs.File to have all necessary interfaces implemented without delegate methods? Something like this

```
type File struct {
        *sftp.File
	client *sftp.Client
}
```

This would allow removing methods `Close Name Stat Sync Truncate Read ReadAt Seek Write WriteAt` which are just simple delegates. I'll gladly implement the change if it's ok otherwise you can just merge this pr as it is.