### PR TITLE
Use PosixRename for sftpfs

### DIFF
--- a/sftpfs/sftp.go
+++ b/sftpfs/sftp.go
@@ -116,7 +116,7 @@ func (s Fs) RemoveAll(path string) error {
 }
 
 func (s Fs) Rename(oldname, newname string) error {
-	return s.client.Rename(oldname, newname)
+	return s.client.PosixRename(oldname, newname)
 }
 
 func (s Fs) Stat(name string) (os.FileInfo, error) {


### PR DESCRIPTION
OpenSSH 4.8 added POSIX-style renames as a protocol extension [1]. The sftp library supports the extension, on both the client and server side, since version 1.13 [2].

For consistency with the other filesystems, it makes sense to use POSIX renames for sftpfs. The old-style rename does not overwrite existing files, which makes it difficult to implement atomic file writes.

[1] https://www.openssh.com/txt/release-4.8
[2] https://github.com/pkg/sftp/pull/384