### PR TITLE
Fix bug in directory detection logic for GCS

### DIFF
--- a/gcsfs/file_info.go
+++ b/gcsfs/file_info.go
@@ -63,7 +63,7 @@ func newFileInfo(name string, fs *Fs, fileMode os.FileMode) (*FileInfo, error) {
 			// such a prefix
 			bucketName, bucketPath := fs.splitName(name)
 			it := fs.client.Bucket(bucketName).Objects(
-				fs.ctx, &storage.Query{Delimiter: fs.separator, Prefix: bucketPath, Versions: false})
+				fs.ctx, &storage.Query{Delimiter: fs.separator, Prefix: fs.ensureTrailingSeparator(bucketPath), Versions: false})
 			if _, err = it.Next(); err == nil {
 				res.name = fs.ensureTrailingSeparator(res.name)
 				res.isDir = true


### PR DESCRIPTION
If a file exists that is a superset of the filename, for example, "file1" and "file12", then this logic would erroneously report the subset path as a directory due to the lack of the trailing delimiter on the prefix.

I don't think the mocks used in unit tests can reproduce this behavior but an example of the behavior using the actual GCS client,

```go
    client := ...
    bucketName := ...

    ctx := context.Background()

    it := client.Bucket(bucketName).Objects(ctx, &storage.Query{Delimiter: "/", Prefix: "testing/file1", Versions: false})
    _, err = it.Next()
    assert.ErrorIs(t, err, iterator.Done)

    object := client.Bucket(bucketName).Object("testing/file12")
    w := object.NewWriter(ctx)
    _, err = w.Write([]byte("test"))
    assert.NoError(t, err)
    err = w.Close()
    assert.NoError(t, err)
    t.Cleanup(func() {
        err := object.Delete(ctx)
        assert.NoError(t, err)
    })

    it = client.Bucket(bucketName).Objects(ctx, &storage.Query{Delimiter: "/", Prefix: "testing/file1/", Versions: false})
    _, err = it.Next()
    assert.ErrorIs(t, err, iterator.Done)

    it = client.Bucket(bucketName).Objects(ctx, &storage.Query{Delimiter: "/", Prefix: "testing/file1", Versions: false})
    _, err = it.Next()
    // This will fail because "file12" is found but that does not mean "file1" is a directory.
    assert.ErrorIs(t, err, iterator.Done)
```