### PR TITLE
construct a new bytes.Reader per each opened file in tarfs

### DIFF
--- a/tarfs/tarfs_test.go
+++ b/tarfs/tarfs_test.go
@@ -185,6 +185,9 @@ func TestMultipleReads(t *testing.T) {
 		}
 
 		fileA, err := afs.Open(f.name)
+		if err != nil {
+			t.Fatalf("opening %v: %v", f.name, err)
+		}
 		fileB, err := afs.Open(f.name)
 		if err != nil {
 			t.Fatalf("opening %v: %v", f.name, err)


### PR DESCRIPTION
Closes #486

Currently, every call to `Open` "copies" the `File`, but since it has pointer fields, it's not really the kind of clean independent copy that's desired here. Notably, every `File` shares the same `bytes.Reader` state.

This causes a few bugs:
- A file which has been read to the end will be unreadable by anyone else.
- Any file which has been `Close`d has had `data` set to `nil`, essentially permanently erasing that file.

My proposed solution is to introduce an internal `fsEntry` type, and to construct a new `tarfs.File` from that data on each call to `Open`. Continuing to share a `*tar.Header` field seems fine, as you shouldn't modify that during normal use.