### PR TITLE
Add support for configurable GCS upload chunk size

### DIFF
--- a/gcsfs/file.go
+++ b/gcsfs/file.go
@@ -90,6 +90,12 @@ func NewGcsFileFromOldFH(
 	return res
 }
 
+// SetUploadChunkSizeByte The default chunk size for uploading files to GCS is 16MB.
+// This buffer size may use memory excessively. You can adjust it to a value that is a multiple of 256KiB.
+func (o *GcsFile) SetUploadChunkSizeByte(size int) {
+	o.resource.uploadChunkSizeByte = size
+}
+
 func (o *GcsFile) Close() error {
 	if o.closed {
 		// the afero spec expects the call to Close on a closed file to return an error

--- a/gcsfs/file.go
+++ b/gcsfs/file.go
@@ -90,9 +90,10 @@ func NewGcsFileFromOldFH(
 	return res
 }
 
-// SetUploadChunkSizeByte The default chunk size for uploading files to GCS is 16MB.
-// This buffer size may use memory excessively. You can adjust it to a value that is a multiple of 256KiB.
-func (o *GcsFile) SetUploadChunkSizeByte(size int) {
+// SetUploadChunkSizeByte sets the chunk size for uploads.
+// To disable chunking, set this to 0.
+// For custom sizes, GCS requires multiples of 256KiB (262144 bytes).
+func (o *GcsFile) SetUploadChunkSizeByte(size *int) {
 	o.resource.uploadChunkSizeByte = size
 }
 

--- a/gcsfs/file_resource.go
+++ b/gcsfs/file_resource.go
@@ -58,7 +58,6 @@ type gcsFileResource struct {
 
 func (o *gcsFileResource) Close() error {
 	o.closed = true
-	// TODO rawGcsObjectsMap ?
 	return o.maybeCloseIo()
 }
 

--- a/gcsfs/fs.go
+++ b/gcsfs/fs.go
@@ -58,6 +58,7 @@ func NewGcsFsWithSeparator(ctx context.Context, client stiface.Client, folderSep
 		client:        client,
 		separator:     folderSep,
 		rawGcsObjects: make(map[string]*GcsFile),
+		buckets:       make(map[string]stiface.BucketHandle),
 
 		autoRemoveEmptyFolders: true,
 	}
@@ -121,6 +122,9 @@ func (fs *Fs) getBucket(name string) (stiface.BucketHandle, error) {
 		if err != nil {
 			return nil, err
 		}
+		fs.mu.Lock()
+		fs.buckets[name] = bucket
+		fs.mu.Unlock()
 	}
 	return bucket, nil
 }

--- a/gcsfs/fs.go
+++ b/gcsfs/fs.go
@@ -43,7 +43,7 @@ type Fs struct {
 	rawGcsObjects map[string]*GcsFile
 
 	autoRemoveEmptyFolders bool // trigger for creating "virtual folders" (not required by GCSs)
-	UploadChunkSizeByte    int
+	UploadChunkSizeByte    *int
 }
 
 func NewGcsFs(ctx context.Context, client stiface.Client) *Fs {
@@ -63,7 +63,7 @@ func NewGcsFsWithSeparator(ctx context.Context, client stiface.Client, folderSep
 
 // SetUploadChunkSizeByte The default chunk size for uploading files to GCS is 16MB.
 // This buffer size may use memory excessively. You can adjust it to a value that is a multiple of 256KiB.
-func (fs *Fs) SetUploadChunkSizeByte(uploadChunkSize int) {
+func (fs *Fs) SetUploadChunkSizeByte(uploadChunkSize *int) {
 	fs.UploadChunkSizeByte = uploadChunkSize
 }
 

--- a/gcsfs/fs.go
+++ b/gcsfs/fs.go
@@ -43,6 +43,7 @@ type Fs struct {
 	rawGcsObjects map[string]*GcsFile
 
 	autoRemoveEmptyFolders bool // trigger for creating "virtual folders" (not required by GCSs)
+	UploadChunkSizeByte    int
 }
 
 func NewGcsFs(ctx context.Context, client stiface.Client) *Fs {
@@ -58,6 +59,12 @@ func NewGcsFsWithSeparator(ctx context.Context, client stiface.Client, folderSep
 
 		autoRemoveEmptyFolders: true,
 	}
+}
+
+// SetUploadChunkSizeByte The default chunk size for uploading files to GCS is 16MB.
+// This buffer size may use memory excessively. You can adjust it to a value that is a multiple of 256KiB.
+func (fs *Fs) SetUploadChunkSizeByte(uploadChunkSize int) {
+	fs.UploadChunkSizeByte = uploadChunkSize
 }
 
 // normSeparators will normalize all "\\" and "/" to the provided separator
@@ -147,6 +154,7 @@ func (fs *Fs) Create(name string) (*GcsFile, error) {
 		return nil, err
 	}
 	w := obj.NewWriter(fs.ctx)
+
 	err = w.Close()
 	if err != nil {
 		return nil, err

--- a/gcsfs/gcs.go
+++ b/gcsfs/gcs.go
@@ -85,7 +85,10 @@ func (fs *GcsFs) Name() string {
 	return fs.source.Name()
 }
 
-func (fs *GcsFs) SetUploadChunkSizeByte(size int) {
+// SetUploadChunkSizeByte sets the chunk size for uploads.
+// To disable chunking, set this to 0.
+// For custom sizes, GCS requires multiples of 256KiB (262144 bytes).
+func (fs *GcsFs) SetUploadChunkSizeByte(size *int) {
 	fs.source.SetUploadChunkSizeByte(size)
 }
 

--- a/gcsfs/gcs.go
+++ b/gcsfs/gcs.go
@@ -85,6 +85,10 @@ func (fs *GcsFs) Name() string {
 	return fs.source.Name()
 }
 
+func (fs *GcsFs) SetUploadChunkSizeByte(size int) {
+	fs.source.SetUploadChunkSizeByte(size)
+}
+
 func (fs *GcsFs) Create(name string) (afero.File, error) {
 	return fs.source.Create(name)
 }


### PR DESCRIPTION
This pull request enhances the GCS upload functionality by introducing a `SetUploadChunkSizeByte` configuration option, allowing users to define custom chunk sizes for uploads. This improvement provides greater flexibility and optimization for specific upload scenarios.