### PR TITLE
fix: add permission checks to MemMapFs Open/OpenFile

### DIFF
--- a/memmap.go
+++ b/memmap.go
@@ -57,6 +57,7 @@ func (m *MemMapFs) Create(name string) (File, error) {
 	name = normalizePath(name)
 	m.mu.Lock()
 	file := mem.CreateFile(name)
+	mem.SetMode(file, 0o666)
 	m.getData()[name] = file
 	m.registerWithParent(file, 0)
 	m.mu.Unlock()
@@ -114,7 +115,11 @@ func (m *MemMapFs) registerWithParent(f *mem.FileData, perm os.FileMode) {
 	parent := m.findParent(f)
 	if parent == nil {
 		pdir := filepath.Dir(filepath.Clean(f.Name()))
-		err := m.lockfreeMkdir(pdir, perm)
+		mkdirPerm := perm
+		if mkdirPerm == 0 {
+			mkdirPerm = 0o755
+		}
+		err := m.lockfreeMkdir(pdir, mkdirPerm)
 		if err != nil {
 			// log.Println("Mkdir error:", err)
 			return
@@ -204,6 +209,10 @@ func normalizePath(path string) string {
 func (m *MemMapFs) Open(name string) (File, error) {
 	f, err := m.open(name)
 	if f != nil {
+		// Check read permission (owner bits).
+		if mem.GetFileInfo(f).Mode().Perm()&0o444 == 0 {
+			return nil, &os.PathError{Op: "open", Path: name, Err: os.ErrPermission}
+		}
 		return mem.NewReadOnlyFileHandle(f), err
 	}
 	return nil, err
@@ -212,6 +221,10 @@ func (m *MemMapFs) Open(name string) (File, error) {
 func (m *MemMapFs) openWrite(name string) (File, error) {
 	f, err := m.open(name)
 	if f != nil {
+		// Check write permission (owner bits).
+		if mem.GetFileInfo(f).Mode().Perm()&0o222 == 0 {
+			return nil, &os.PathError{Op: "open", Path: name, Err: os.ErrPermission}
+		}
 		return mem.NewFileHandle(f), err
 	}
 	return nil, err
@@ -382,11 +395,11 @@ func (m *MemMapFs) LstatIfPossible(name string) (os.FileInfo, bool, error) {
 }
 
 func (m *MemMapFs) Stat(name string) (os.FileInfo, error) {
-	f, err := m.Open(name)
+	f, err := m.open(name)
 	if err != nil {
 		return nil, err
 	}
-	fi := mem.GetFileInfo(f.(*mem.File).Data())
+	fi := mem.GetFileInfo(f)
 	return fi, nil
 }
 

--- a/memmap_test.go
+++ b/memmap_test.go
@@ -918,3 +918,94 @@ func TestMemMapFsRename(t *testing.T) {
 		}
 	}
 }
+
+func TestMemMapFsPermissionChecks(t *testing.T) {
+	// Verify that MemMapFs.Open checks file permissions, matching
+	// real filesystem behavior.
+	// See https://github.com/spf13/afero/issues/150
+	fs := &MemMapFs{}
+
+	// Create a file (should get default 0666 permission).
+	f, err := fs.Create("/test.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.WriteString("hello")
+	f.Close()
+
+	info, err := fs.Stat("/test.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o666 {
+		t.Fatalf("expected default permission 0666, got %o", info.Mode().Perm())
+	}
+
+	// File should be readable.
+	f, err = fs.Open("/test.txt")
+	if err != nil {
+		t.Fatalf("Open should succeed with 0666 permissions: %v", err)
+	}
+	f.Close()
+
+	// Chmod to 0 (no permissions).
+	err = fs.Chmod("/test.txt", 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Open for reading should fail.
+	_, err = fs.Open("/test.txt")
+	if err == nil {
+		t.Fatal("Open should fail with 0 permissions")
+	}
+	if !os.IsPermission(err) {
+		t.Fatalf("expected permission error, got: %v", err)
+	}
+
+	// OpenFile for writing should also fail.
+	_, err = fs.OpenFile("/test.txt", os.O_WRONLY, 0)
+	if err == nil {
+		t.Fatal("OpenFile (write) should fail with 0 permissions")
+	}
+	if !os.IsPermission(err) {
+		t.Fatalf("expected permission error, got: %v", err)
+	}
+
+	// Chmod to 0444 (read-only).
+	err = fs.Chmod("/test.txt", 0o444)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Open for reading should succeed.
+	f, err = fs.Open("/test.txt")
+	if err != nil {
+		t.Fatalf("Open should succeed with 0444 permissions: %v", err)
+	}
+	f.Close()
+
+	// OpenFile for writing should fail.
+	_, err = fs.OpenFile("/test.txt", os.O_WRONLY, 0)
+	if err == nil {
+		t.Fatal("OpenFile (write) should fail with 0444 permissions")
+	}
+	if !os.IsPermission(err) {
+		t.Fatalf("expected permission error, got: %v", err)
+	}
+
+	// Chmod to 0222 (write-only).
+	err = fs.Chmod("/test.txt", 0o222)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Open for reading should fail.
+	_, err = fs.Open("/test.txt")
+	if err == nil {
+		t.Fatal("Open (read) should fail with 0222 permissions")
+	}
+	if !os.IsPermission(err) {
+		t.Fatalf("expected permission error, got: %v", err)
+	}
+}


### PR DESCRIPTION
Fixes #150

Right now MemMapFs ignores file permissions completely -- you can chmod a file to 0 and still open/read it without any error. This makes it pretty much impossible to use MemMapFs for testing code that cares about file permissions.

This PR adds basic permission checking:

- `Open()` checks read permission bits (0444) before returning a handle
- `openWrite()` checks write permission bits (0222) before returning a handle
- `Create()` now defaults to 0666 permissions, matching what `os.Create()` does
- `Stat()` bypasses the permission check (uses internal `open()`) since real `stat(2)` doesn't require read permission either
- Auto-created parent directories in `registerWithParent` now get 0755 instead of 0, so they stay accessible

The permission model is simplified -- it checks any read/write bit being set rather than doing full uid/gid owner/group/other matching. This keeps things straightforward while still catching the common case of chmod 0 or testing read-only vs write-only scenarios.