### PR TITLE
fix: MemMapFs.Remove returns error for non-empty directories

### DIFF
--- a/memmap.go
+++ b/memmap.go
@@ -22,6 +22,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/spf13/afero/mem"
@@ -282,7 +283,17 @@ func (m *MemMapFs) Remove(name string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if _, ok := m.getData()[name]; ok {
+	if f, ok := m.getData()[name]; ok {
+		fi := mem.GetFileInfo(f)
+		if fi.IsDir() {
+			// Check if directory has children
+			prefix := name + FilePathSeparator
+			for p := range m.getData() {
+				if strings.HasPrefix(p, prefix) {
+					return &os.PathError{Op: "remove", Path: name, Err: syscall.ENOTEMPTY}
+				}
+			}
+		}
 		err := m.unRegisterWithParent(name)
 		if err != nil {
 			return &os.PathError{Op: "remove", Path: name, Err: err}


### PR DESCRIPTION
Fixes #232

## Problem

`MemMapFs.Remove()` silently removes a non-empty directory and all its contents. This violates the `os.Remove` contract, which returns `ENOTEMPTY` for non-empty directories.

```go
fs := afero.NewMemMapFs()
fs.MkdirAll("/dirname", 0755)
afero.WriteFile(fs, "/dirname/file", []byte("data"), 0644)
fs.Remove("/dirname") // succeeds, should fail with ENOTEMPTY
```

## Fix

Before removing a directory, check if any entries have the directory path as a prefix. If children exist, return `&os.PathError{Op: "remove", Path: name, Err: syscall.ENOTEMPTY}`.

This matches the behavior of `os.Remove` on real filesystems.