### PR TITLE
fix: return os.ErrClosed on double Close() in MemMapFs

### DIFF
--- a/mem/file.go
+++ b/mem/file.go
@@ -128,6 +128,10 @@ func (f *File) Open() error {
 
 func (f *File) Close() error {
 	f.fileData.Lock()
+	if f.closed {
+		f.fileData.Unlock()
+		return os.ErrClosed
+	}
 	f.closed = true
 	if !f.readOnly {
 		setModTime(f.fileData, time.Now())


### PR DESCRIPTION
Fixes #567

## Problem

`mem.File.Close()` silently succeeds when called multiple times, while `os.File.Close()` returns an error (`os.ErrClosed`). This inconsistency causes bugs to go undetected in tests using MemMapFs that only surface in production with OsFs.

## Fix

Check the `closed` flag under the lock before proceeding. If already closed, return `os.ErrClosed` to match `os.File` behavior.

## Testing

All existing tests pass.