### PR TITLE
mem: return ErrFileClosed on double Close

### DIFF
--- a/mem/file.go
+++ b/mem/file.go
@@ -128,11 +128,14 @@ func (f *File) Open() error {
 
 func (f *File) Close() error {
 	f.fileData.Lock()
+	defer f.fileData.Unlock()
+	if f.closed {
+		return ErrFileClosed
+	}
 	f.closed = true
 	if !f.readOnly {
 		setModTime(f.fileData, time.Now())
 	}
-	f.fileData.Unlock()
 	return nil
 }
 


### PR DESCRIPTION
Closes #567. MemMapFS silently allowed double Close while OsFS errors; tests against MemMapFS missed the bug. Match OsFS.