### PR TITLE
mem: return error when reading a directory (fixes #430)

### DIFF
--- a/mem/file.go
+++ b/mem/file.go
@@ -219,6 +219,9 @@ func (f *File) ReadAt(b []byte, off int64) (n int, err error) {
 	if f.closed {
 		return 0, ErrFileClosed
 	}
+	if f.fileData.dir {
+		return 0, &os.PathError{Op: "read", Path: f.fileData.name, Err: errors.New("is a directory")}
+	}
 	if len(b) > 0 && int(off) == len(f.fileData.data) {
 		return 0, io.EOF
 	}

--- a/util_test.go
+++ b/util_test.go
@@ -489,3 +489,14 @@ func TestFullBaseFsPath(t *testing.T) {
 		}
 	}
 }
+
+func TestReadFileOnDirectory(t *testing.T) {
+	fs := NewMemMapFs()
+	if err := fs.Mkdir("/testdir", 0o755); err != nil {
+		t.Fatal(err)
+	}
+	_, err := ReadFile(fs, "/testdir")
+	if err == nil {
+		t.Fatal("ReadFile on a directory should return an error, got nil")
+	}
+}


### PR DESCRIPTION
## Summary

`afero.ReadFile(fs, dirPath)` on a `MemMapFs` silently returned empty content with a `nil` error. The real OS filesystem returns an error (`read /some/dir: is a directory`). This inconsistency was reported in #430.

### Root cause

`(*File).Read` delegates to `ReadAt`, which had no guard for directory-backed files. It would simply return `n=0, err=nil` because the file data slice is empty for directories.

### Fix

Added a directory check at the top of `ReadAt`:

```go
if f.fileData.dir {
    return 0, &os.PathError{Op: "read", Path: f.fileData.name, Err: errors.New("is a directory")}
}
```

`Read` already delegates to `ReadAt`, so both are covered by one guard.

### Test

Added `TestReadFileOnDirectory` in `util_test.go` that:
1. Creates a `MemMapFs` directory
2. Calls `afero.ReadFile` on it
3. Asserts a non-nil error is returned

```
$ go test ./... -run TestReadFile
ok      github.com/spf13/afero  0.6s
```

Full test suite passes without regressions.

Fixes #430