### PR TITLE
MemMapFs: Mkdir now errors when the parent directory doesn't exist

### DIFF
--- a/composite_test.go
+++ b/composite_test.go
@@ -447,7 +447,7 @@ func TestUnionFileReaddirDuplicateEmpty(t *testing.T) {
 
 	// Overlay shares same empty directory as base
 	overlay := NewMemMapFs()
-	err = overlay.Mkdir(dir, 0o700)
+	err = overlay.MkdirAll(dir, 0o700)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/ioutil.go
+++ b/ioutil.go
@@ -226,6 +226,12 @@ func TempDir(fs Fs, dir, prefix string) (name string, err error) {
 		dir = os.TempDir()
 	}
 
+	// Ensure the base directory exists (important for in-memory filesystems
+	// where the path may not have been created yet).
+	if err = fs.MkdirAll(dir, 0o700); err != nil {
+		return
+	}
+
 	nconflict := 0
 	for i := 0; i < 10000; i++ {
 		try := filepath.Join(dir, prefix+nextRandom())

--- a/memmap.go
+++ b/memmap.go
@@ -167,11 +167,22 @@ func (m *MemMapFs) Mkdir(name string, perm os.FileMode) error {
 	}
 
 	m.mu.Lock()
-	// Dobule check that it doesn't exist.
+	// Double check that it doesn't exist.
 	if _, ok := m.getData()[name]; ok {
 		m.mu.Unlock()
 		return &os.PathError{Op: "mkdir", Path: name, Err: ErrFileExists}
 	}
+
+	// The parent directory must already exist, matching os.Mkdir behavior.
+	// The root directory is implicitly always present, so only check non-root parents.
+	pdir := filepath.Dir(name)
+	if pdir != name && pdir != "/" && pdir != "." {
+		if _, ok := m.getData()[pdir]; !ok {
+			m.mu.Unlock()
+			return &os.PathError{Op: "mkdir", Path: name, Err: os.ErrNotExist}
+		}
+	}
+
 	item := mem.CreateDir(name)
 	mem.SetMode(item, os.ModeDir|perm)
 	m.getData()[name] = item
@@ -182,9 +193,31 @@ func (m *MemMapFs) Mkdir(name string, perm os.FileMode) error {
 }
 
 func (m *MemMapFs) MkdirAll(path string, perm os.FileMode) error {
+	path = normalizePath(path)
+
+	m.mu.RLock()
+	existing, exists := m.getData()[path]
+	m.mu.RUnlock()
+	if exists {
+		fi := mem.FileInfo{FileData: existing}
+		if fi.IsDir() {
+			return nil
+		}
+		return &os.PathError{Op: "mkdir", Path: path, Err: ErrFileExists}
+	}
+
+	// Recursively ensure parent exists before creating the leaf directory.
+	parent := filepath.Dir(path)
+	if parent != path && parent != "/" && parent != "." {
+		if err := m.MkdirAll(parent, perm); err != nil {
+			return err
+		}
+	}
+
 	err := m.Mkdir(path, perm)
 	if err != nil {
-		if err.(*os.PathError).Err == ErrFileExists {
+		// Another goroutine may have created it concurrently; that's fine.
+		if pathErr, ok := err.(*os.PathError); ok && pathErr.Err == ErrFileExists {
 			return nil
 		}
 		return err

--- a/memmap_test.go
+++ b/memmap_test.go
@@ -67,6 +67,10 @@ func TestPathErrors(t *testing.T) {
 
 	// fs.Create doesn't return an error
 
+	// Create parent directories first so Mkdir of the leaf can succeed.
+	if err = fs.MkdirAll(filepath.Dir(path2), perm); err != nil {
+		t.Fatalf("MkdirAll for Mkdir parent: %v", err)
+	}
 	err = fs.Mkdir(path2, perm)
 	if err != nil {
 		t.Error(err)
@@ -632,6 +636,44 @@ func TestMemFsChmod(t *testing.T) {
 }
 
 // can't use Mkdir to get around which permissions we're allowed to set
+// Mkdir should return an error when the parent directory does not exist,
+// matching the behavior of os.Mkdir. See issue #149.
+func TestMemFsMkdirRequiresParent(t *testing.T) {
+	t.Parallel()
+
+	fs := NewMemMapFs()
+
+	// Creating a deep path without any parents should fail.
+	err := fs.Mkdir("/a/b/c", 0o755)
+	if err == nil {
+		t.Fatal("expected error when parent /a/b does not exist, got nil")
+	}
+
+	// Creating a top-level directory (parent is root) should succeed.
+	if err = fs.Mkdir("/a", 0o755); err != nil {
+		t.Fatalf("Mkdir /a: %v", err)
+	}
+
+	// Creating a child once its parent exists should succeed.
+	if err = fs.Mkdir("/a/b", 0o755); err != nil {
+		t.Fatalf("Mkdir /a/b: %v", err)
+	}
+
+	// MkdirAll must still create the full hierarchy.
+	if err = fs.MkdirAll("/x/y/z", 0o755); err != nil {
+		t.Fatalf("MkdirAll /x/y/z: %v", err)
+	}
+	for _, p := range []string{"/x", "/x/y", "/x/y/z"} {
+		info, err := fs.Stat(p)
+		if err != nil {
+			t.Fatalf("Stat %s: %v", p, err)
+		}
+		if !info.IsDir() {
+			t.Fatalf("%s should be a directory", p)
+		}
+	}
+}
+
 func TestMemFsMkdirModeIllegal(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Fixes #149.

`MemMapFs.Mkdir` was silently creating any missing parent directories via `registerWithParent`, so it behaved like `MkdirAll`. This diverges from `os.Mkdir`, which returns `ENOENT` when the parent doesn't exist.

The practical problem: if you have a typo in a path, `Mkdir` would happily create the whole tree rather than failing, masking the bug entirely. That's the kind of thing that makes test suites using `MemMapFs` pass while production code (using `OsFs`) fails.

**Changes:**

- `Mkdir` checks that the parent directory exists before creating the new one. If the parent is missing it returns `os.ErrNotExist`.
- `MkdirAll` is rewritten to explicitly recurse over missing parents, since it can no longer rely on `Mkdir`'s old implicit creation.
- `TempDir` now calls `MkdirAll` on the base dir before calling `Mkdir`, since in-memory filesystems start empty.
- Two tests that called `Mkdir` with deep paths expecting the old behavior are updated.

**Before:**
```go
fs := afero.NewMemMapFs()
err := fs.Mkdir("/a/b/c", 0755) // nil — creates /a, /a/b, and /a/b/c silently
```

**After:**
```go
err := fs.Mkdir("/a/b/c", 0755)
// mkdir /a/b/c: file does not exist
```