### PR TITLE
fix(mem): implement io.ReaderFrom on MemMapFs files

### DIFF
--- a/mem/file.go
+++ b/mem/file.go
@@ -30,7 +30,10 @@ import (
 
 const FilePathSeparator = string(filepath.Separator)
 
-var _ fs.ReadDirFile = &File{}
+var (
+	_ fs.ReadDirFile = &File{}
+	_ io.ReaderFrom  = (*File)(nil)
+)
 
 type File struct {
 	// atomic requires 64-bit alignment for struct field access
@@ -327,6 +330,48 @@ func (f *File) Write(b []byte) (n int, err error) {
 
 func (f *File) WriteString(s string) (ret int, err error) {
 	return f.Write([]byte(s))
+}
+
+// ReadFrom implements io.ReaderFrom.
+func (f *File) ReadFrom(r io.Reader) (n int64, err error) {
+	if f.closed {
+		return 0, ErrFileClosed
+	}
+	if f.readOnly {
+		return 0, &os.PathError{
+			Op:   "write",
+			Path: f.fileData.name,
+			Err:  errors.New("file handle is read only"),
+		}
+	}
+	off := atomic.LoadInt64(&f.at)
+	n, err = readAtWriter(f, off, r)
+	atomic.StoreInt64(&f.at, off+n)
+	return n, err
+}
+
+func readAtWriter(w io.WriterAt, off int64, r io.Reader) (int64, error) {
+	buf := make([]byte, 32*1024)
+	var total int64
+	for {
+		nr, er := r.Read(buf)
+		if nr > 0 {
+			nw, ew := w.WriteAt(buf[:nr], off+total)
+			total += int64(nw)
+			if ew != nil {
+				return total, ew
+			}
+			if nw < nr {
+				return total, io.ErrShortWrite
+			}
+		}
+		if er != nil {
+			if er == io.EOF {
+				return total, nil
+			}
+			return total, er
+		}
+	}
 }
 
 func (f *File) Info() *FileInfo {

--- a/mem/file_test.go
+++ b/mem/file_test.go
@@ -269,6 +269,31 @@ func TestFileReadAtSeekOffset(t *testing.T) {
 	}
 }
 
+func TestFileReadFrom(t *testing.T) {
+	fd := CreateFile("readfrom.txt")
+	f := NewFileHandle(fd)
+
+	rf, ok := any(f).(io.ReaderFrom)
+	if !ok {
+		t.Fatal("mem.File should implement io.ReaderFrom")
+	}
+
+	payload := []byte("payload")
+	n, err := rf.ReadFrom(bytes.NewReader(payload))
+	if err != nil {
+		t.Fatalf("ReadFrom: %v", err)
+	}
+	if n != int64(len(payload)) {
+		t.Fatalf("ReadFrom bytes: got %d want %d", n, len(payload))
+	}
+	if got := string(fd.data); got != "payload" {
+		t.Fatalf("file data: got %q want %q", got, "payload")
+	}
+	if at, _ := f.Seek(0, io.SeekCurrent); at != int64(len(payload)) {
+		t.Fatalf("offset after ReadFrom: got %d want %d", at, len(payload))
+	}
+}
+
 func TestFileWriteAndSeek(t *testing.T) {
 	fd := CreateFile("foo")
 	f := NewFileHandle(fd)

--- a/memmap_readfrom_test.go
+++ b/memmap_readfrom_test.go
@@ -1,0 +1,62 @@
+package afero
+
+import (
+	"bytes"
+	"io"
+	"testing"
+)
+
+func TestMemMapFsFileImplementsReaderFrom(t *testing.T) {
+	fs := NewMemMapFs()
+	dst, err := fs.Create("dst.txt")
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	defer dst.Close()
+
+	rf, ok := dst.(io.ReaderFrom)
+	if !ok {
+		t.Fatal("MemMapFs file should implement io.ReaderFrom")
+	}
+
+	n, err := rf.ReadFrom(bytes.NewReader([]byte("payload")))
+	if err != nil {
+		t.Fatalf("ReadFrom: %v", err)
+	}
+	if n != int64(len("payload")) {
+		t.Fatalf("ReadFrom bytes: got %d", n)
+	}
+
+	got, err := ReadFile(fs, "dst.txt")
+	if err != nil {
+		t.Fatalf("read file: %v", err)
+	}
+	if string(got) != "payload" {
+		t.Fatalf("file contents: got %q", string(got))
+	}
+}
+
+func TestMemMapFsIoCopyUsesReadFrom(t *testing.T) {
+	fs := NewMemMapFs()
+	dst, err := fs.Create("dst.txt")
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	defer dst.Close()
+
+	n, err := io.Copy(dst, bytes.NewReader([]byte("payload")))
+	if err != nil {
+		t.Fatalf("copy: %v", err)
+	}
+	if n != int64(len("payload")) {
+		t.Fatalf("copied bytes: got %d", n)
+	}
+
+	got, err := ReadFile(fs, "dst.txt")
+	if err != nil {
+		t.Fatalf("read file: %v", err)
+	}
+	if string(got) != "payload" {
+		t.Fatalf("file contents: got %q", string(got))
+	}
+}


### PR DESCRIPTION
## Summary

- Implements `io.ReaderFrom` on `mem.File` so `MemMapFs` files behave like `*os.File` for `io.Copy` fast paths.
- `ReadFrom` writes starting at the current file offset and advances it, matching `os.File` semantics.
- Adds unit tests in `mem` and integration tests for `MemMapFs`.

Fixes #498

## Test plan

- [x] `go test ./...`