### PR TITLE
fix(mem): align MemMapFs Stat with os.FileInfo behavior

### DIFF
--- a/mem/file.go
+++ b/mem/file.go
@@ -340,9 +340,9 @@ type FileInfo struct {
 // Implements os.FileInfo
 func (s *FileInfo) Name() string {
 	s.Lock()
-	_, name := filepath.Split(s.name)
+	name := s.name
 	s.Unlock()
-	return name
+	return filepath.Base(name)
 }
 
 func (s *FileInfo) Mode() os.FileMode {

--- a/memmap.go
+++ b/memmap.go
@@ -402,8 +402,14 @@ func (m *MemMapFs) LstatIfPossible(name string) (os.FileInfo, bool, error) {
 }
 
 func (m *MemMapFs) Stat(name string) (os.FileInfo, error) {
+	if name == "" {
+		return nil, &os.PathError{Op: "stat", Path: name, Err: ErrFileNotFound}
+	}
 	f, err := m.open(name)
 	if err != nil {
+		if pe, ok := err.(*os.PathError); ok {
+			return nil, &os.PathError{Op: "stat", Path: pe.Path, Err: pe.Err}
+		}
 		return nil, err
 	}
 	fi := mem.GetFileInfo(f)

--- a/memmap_stat_test.go
+++ b/memmap_stat_test.go
@@ -1,0 +1,41 @@
+package afero
+
+import (
+	"errors"
+	"os"
+	"testing"
+)
+
+func TestMemMapFsStatEmptyPath(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewMemMapFs().Stat("")
+	if err == nil {
+		t.Fatal("expected error for empty path, got nil")
+	}
+
+	var pathErr *os.PathError
+	if !errors.As(err, &pathErr) {
+		t.Fatalf("expected *os.PathError, got %T", err)
+	}
+	if pathErr.Op != "stat" {
+		t.Fatalf("expected Op stat, got %q", pathErr.Op)
+	}
+
+	_, err = os.Stat("")
+	if err == nil {
+		t.Fatal(`os.Stat("") should fail for comparison`)
+	}
+}
+
+func TestMemMapFsStatRootName(t *testing.T) {
+	t.Parallel()
+
+	info, err := NewMemMapFs().Stat("/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Name() != FilePathSeparator {
+		t.Fatalf("expected root name %q, got %q", FilePathSeparator, info.Name())
+	}
+}


### PR DESCRIPTION
## Summary

- `MemMapFs.Stat("")` now returns a `*os.PathError` with `Op: "stat"` instead of surfacing an internal `open` error
- `FileInfo.Name()` uses `filepath.Base`, so `Stat("/")` reports `"/"` like `os.Stat` instead of `""`

## Problem

Injectable filesystem tests comparing against `os.Stat` were tripped up by two MemMapFs divergences:

1. Empty path stat errors used `Op: "open"` (issue #522)
2. Root directory `Name()` was `""` because `filepath.Split("/")` yields an empty base name (issue #222)

## Test plan

- [x] Added `TestMemMapFsStatEmptyPath`
- [x] Added `TestMemMapFsStatRootName`
- [x] `go test ./...`

Fixes #522
Fixes #222