### PR TITLE
fix(mem): return EISDIR when reading from directory handles

### DIFF
--- a/ioutil_test.go
+++ b/ioutil_test.go
@@ -16,8 +16,11 @@
 package afero
 
 import (
+	"errors"
+	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
 )
 
@@ -49,6 +52,23 @@ func TestReadFile(t *testing.T) {
 	}
 
 	checkSizePath(t, filename, int64(len(contents)))
+}
+
+func TestReadFileDirectoryMemMapFs(t *testing.T) {
+	fs := NewMemMapFs()
+	if err := fs.Mkdir("/dir", 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := ReadFile(fs, "/dir")
+	if err == nil {
+		t.Fatal("expected error reading directory")
+	}
+
+	var pe *os.PathError
+	if !errors.As(err, &pe) || !errors.Is(pe.Err, syscall.EISDIR) {
+		t.Fatalf("expected EISDIR PathError, got %v", err)
+	}
 }
 
 func TestWriteFile(t *testing.T) {

--- a/mem/file.go
+++ b/mem/file.go
@@ -23,6 +23,7 @@ import (
 	"path/filepath"
 	"sync"
 	"sync/atomic"
+	"syscall"
 	"time"
 
 	"github.com/spf13/afero/internal/common"
@@ -219,6 +220,9 @@ func (f *File) ReadAt(b []byte, off int64) (n int, err error) {
 	if f.closed {
 		return 0, ErrFileClosed
 	}
+	if f.fileData.dir {
+		return 0, &os.PathError{Op: "read", Path: f.fileData.name, Err: syscall.EISDIR}
+	}
 	if len(b) > 0 && int(off) == len(f.fileData.data) {
 		return 0, io.EOF
 	}
@@ -250,6 +254,9 @@ func (f *File) Truncate(size int64) error {
 	if f.closed {
 		return ErrFileClosed
 	}
+	if f.fileData.dir {
+		return &os.PathError{Op: "truncate", Path: f.fileData.name, Err: syscall.EISDIR}
+	}
 	if f.readOnly {
 		return &os.PathError{
 			Op:   "truncate",
@@ -276,6 +283,9 @@ func (f *File) Seek(offset int64, whence int) (int64, error) {
 	if f.closed {
 		return 0, ErrFileClosed
 	}
+	if f.fileData.dir {
+		return 0, &os.PathError{Op: "seek", Path: f.fileData.name, Err: syscall.EISDIR}
+	}
 	switch whence {
 	case io.SeekStart:
 		atomic.StoreInt64(&f.at, offset)
@@ -290,6 +300,9 @@ func (f *File) Seek(offset int64, whence int) (int64, error) {
 func (f *File) WriteAt(b []byte, off int64) (n int, err error) {
 	if f.closed {
 		return 0, ErrFileClosed
+	}
+	if f.fileData.dir {
+		return 0, &os.PathError{Op: "write", Path: f.fileData.name, Err: syscall.EISDIR}
 	}
 	if f.readOnly {
 		return 0, &os.PathError{


### PR DESCRIPTION
## Summary

Fixes #201

`afero.ReadFile` on a directory path with `MemMapFs` previously returned empty data without error. The in-memory file handle allowed `Read`/`ReadAt` on directory nodes.

This change aligns `mem.File` with `tarfs`, `zipfs`, and `gcsfs` by returning a `PathError` wrapping `syscall.EISDIR` for read, write, seek, and truncate operations on directories.

## Test plan

- [x] `go test ./...`
- [x] Added `TestReadFileDirectoryMemMapFs`