### PR TITLE
fix: strip nested BasePathFs prefixes in file names

### DIFF
--- a/basepath.go
+++ b/basepath.go
@@ -35,9 +35,49 @@ type BasePathFile struct {
 	path string
 }
 
+func basePathRelName(basePath, sourceName string) string {
+	basePath = filepath.Clean(basePath)
+	sourceName = filepath.Clean(sourceName)
+
+	if rel, err := filepath.Rel(basePath, sourceName); err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		if strings.HasPrefix(basePath, string(filepath.Separator)) {
+			if rel == "." {
+				return string(filepath.Separator)
+			}
+			if strings.HasPrefix(rel, string(filepath.Separator)) {
+				return rel
+			}
+			return string(filepath.Separator) + rel
+		}
+		return rel
+	}
+
+	prefixes := []string{
+		basePath + string(filepath.Separator),
+		string(filepath.Separator) + basePath + string(filepath.Separator),
+	}
+	for _, prefix := range prefixes {
+		if after, ok := strings.CutPrefix(sourceName, prefix); ok {
+			if strings.HasPrefix(basePath, string(filepath.Separator)) && !strings.HasPrefix(after, string(filepath.Separator)) {
+				return string(filepath.Separator) + after
+			}
+			return after
+		}
+	}
+
+	trimmed := strings.TrimPrefix(sourceName, basePath)
+	if trimmed != sourceName {
+		if len(trimmed) > 0 && trimmed[0] == filepath.Separator && !strings.HasPrefix(basePath, string(filepath.Separator)) {
+			return trimmed[1:]
+		}
+		return trimmed
+	}
+
+	return sourceName
+}
+
 func (f *BasePathFile) Name() string {
-	sourcename := f.File.Name()
-	return strings.TrimPrefix(sourcename, filepath.Clean(f.path))
+	return basePathRelName(f.path, f.File.Name())
 }
 
 func (f *BasePathFile) ReadDir(n int) ([]fs.DirEntry, error) {

--- a/basepath_test.go
+++ b/basepath_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 )
 
@@ -305,5 +306,28 @@ func TestBasePathTempFile(t *testing.T) {
 	defer tempFile.Close()
 	if expected, actual := tDir, filepath.Dir(tempFile.Name()); expected != actual {
 		t.Fatalf("TempFile realpath leaked: expected %s, got %s", expected, actual)
+	}
+}
+
+func TestNestedBasePathTempFileName(t *testing.T) {
+	base := NewMemMapFs()
+	if err := base.MkdirAll("/files/123", 0o755); err != nil {
+		t.Fatal(err)
+	}
+	fs1 := NewBasePathFs(base, "files")
+	fs2 := NewBasePathFs(fs1, "123")
+
+	tmp, err := TempFile(fs2, ".", "afero-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tmp.Close()
+
+	name := tmp.Name()
+	if strings.HasPrefix(name, "/") {
+		t.Fatalf("Name() leaked base path prefix, got %q", name)
+	}
+	if err := fs2.Chmod(name, 0o644); err != nil {
+		t.Fatalf("Chmod(%q) failed: %v", name, err)
 	}
 }


### PR DESCRIPTION
## Summary

- Fixes `BasePathFile.Name()` returning paths that still contain parent base prefixes when `BasePathFs` instances are nested
- Replace naive `strings.TrimPrefix(filepath.Clean(base))` with relative-name computation that handles mixed absolute/relative base paths and separator prefixes

## Test plan

- [x] Added `TestNestedBasePathTempFileName` reproducing nested `TempFile` + `Chmod` failure
- [x] Existing `TestBasePath*` and nested copy tests still pass
- [x] `go test ./...`

Fixes #428