### PR TITLE
fix: only enforce O_EXCL on MemMapFs when O_CREATE is set

### DIFF
--- a/memmap.go
+++ b/memmap.go
@@ -263,7 +263,7 @@ func (m *MemMapFs) OpenFile(name string, flag int, perm os.FileMode) (File, erro
 	perm &= chmodBits
 	chmod := false
 	file, err := m.openWrite(name)
-	if err == nil && (flag&os.O_EXCL > 0) {
+	if err == nil && (flag&os.O_CREATE > 0) && (flag&os.O_EXCL > 0) {
 		return nil, &os.PathError{Op: "open", Path: name, Err: ErrFileExists}
 	}
 	if os.IsNotExist(err) && (flag&os.O_CREATE > 0) {

--- a/memmap_test.go
+++ b/memmap_test.go
@@ -135,6 +135,25 @@ func TestOpenFileExcl(t *testing.T) {
 	checkPathError(t, err, "Open")
 }
 
+func TestOpenFileExclWithoutCreate(t *testing.T) {
+	const fileName = "/myFileTestExclReopen"
+	const fileMode = os.FileMode(0o644)
+
+	fs := NewMemMapFs()
+
+	f, err := fs.OpenFile(fileName, os.O_CREATE|os.O_RDWR|os.O_EXCL, fileMode)
+	if err != nil {
+		t.Fatalf("OpenFile create with O_EXCL failed: %s", err)
+	}
+	f.Close()
+
+	f, err = fs.OpenFile(fileName, os.O_RDWR|os.O_EXCL, fileMode)
+	if err != nil {
+		t.Fatalf("OpenFile reopen with O_EXCL (no O_CREATE) failed: %s", err)
+	}
+	f.Close()
+}
+
 // Ensure Permissions are set on OpenFile/Mkdir/MkdirAll
 func TestPermSet(t *testing.T) {
 	const fileName = "/myFileTest"


### PR DESCRIPTION
## Summary

`MemMapFs.OpenFile` treated `O_EXCL` as "file must not exist" on every open. That breaks reopens such as `O_RDWR|O_EXCL` after the file was already created, while the real OS ignores `O_EXCL` unless `O_CREATE` is also set.

Only return `ErrFileExists` when both `O_CREATE` and `O_EXCL` are present and the file already exists.

Fixes #415

## Test plan

- [x] `go test ./...`
- [x] Existing `TestOpenFileExcl` still passes (create+excl twice fails as expected)
- [x] Added `TestOpenFileExclWithoutCreate` for create then reopen with `O_RDWR|O_EXCL`