### PR TITLE
feat: add branded ErrPermission, ErrDeadlineExceeded, and ErrNotDir

### DIFF
--- a/afero.go
+++ b/afero.go
@@ -26,6 +26,7 @@ import (
 	"errors"
 	"io"
 	"os"
+	"syscall"
 	"time"
 )
 
@@ -108,4 +109,7 @@ var (
 	ErrFileNotFound      = os.ErrNotExist
 	ErrFileExists        = os.ErrExist
 	ErrDestinationExists = os.ErrExist
+	ErrPermission        = os.ErrPermission
+	ErrDeadlineExceeded  = os.ErrDeadlineExceeded
+	ErrNotDir            = syscall.ENOTDIR
 )

--- a/errors_test.go
+++ b/errors_test.go
@@ -1,0 +1,20 @@
+package afero
+
+import (
+	"errors"
+	"os"
+	"syscall"
+	"testing"
+)
+
+func TestBrandedErrorsMatchStandardLibrary(t *testing.T) {
+	if !errors.Is(ErrPermission, os.ErrPermission) {
+		t.Fatal("ErrPermission should match os.ErrPermission")
+	}
+	if !errors.Is(ErrDeadlineExceeded, os.ErrDeadlineExceeded) {
+		t.Fatal("ErrDeadlineExceeded should match os.ErrDeadlineExceeded")
+	}
+	if !errors.Is(ErrNotDir, syscall.ENOTDIR) {
+		t.Fatal("ErrNotDir should match syscall.ENOTDIR")
+	}
+}


### PR DESCRIPTION
## Summary

Custom `Fs` implementations currently mix afero-branded errors with direct `os`/`syscall` values. This adds common filesystem errors as exported afero variables aliasing the standard library:

- `ErrPermission` → `os.ErrPermission`
- `ErrDeadlineExceeded` → `os.ErrDeadlineExceeded`
- `ErrNotDir` → `syscall.ENOTDIR`

Fixes #495

## Test plan

- [x] `go test ./...`
- [x] Added `TestBrandedErrorsMatchStandardLibrary`