### PR TITLE
chore: improve afero maintenance path

### DIFF
--- a/iofs_test.go
+++ b/iofs_test.go
@@ -200,7 +200,7 @@ func TestFromIOFS(t *testing.T) {
 	})
 
 	t.Run("MkdirAll", func(t *testing.T) {
-		err := fromIOFS.Mkdir("test", 0)
+		err := fromIOFS.MkdirAll("test", 0)
 		assertPermissionError(t, err)
 	})
 
@@ -257,6 +257,11 @@ func TestFromIOFS(t *testing.T) {
 
 	t.Run("Remove", func(t *testing.T) {
 		err := fromIOFS.Remove("test")
+		assertPermissionError(t, err)
+	})
+
+	t.Run("RemoveAll", func(t *testing.T) {
+		err := fromIOFS.RemoveAll("test")
 		assertPermissionError(t, err)
 	})
 


### PR DESCRIPTION
Summary:
- Add or tighten focused edge-case tests or type assertions in iofs_test.go, path_test.go related to CI, Docker, Kubernetes, build tooling, release automation; avoid docs-only changes and broad refactors.
- Keep the change narrow so it is straightforward to review.

Notes:
- I kept this scoped to the relevant implementation and tests.