### PR TITLE
Preserve WriterTo/ReaderFrom in RegexpFile (match #577)

### DIFF
--- a/regexp_copy_sibling_test.go
+++ b/regexp_copy_sibling_test.go
@@ -1,0 +1,84 @@
+package afero
+
+import (
+	"bytes"
+	"io"
+	"regexp"
+	"testing"
+)
+
+// --- tracking harness (same shape as basepath_copy_test.go's optionalIfaceFs) ---
+
+type sibOptionalIfaceFs struct {
+	Fs
+	openWrap func(File) File
+}
+
+func (f sibOptionalIfaceFs) Open(name string) (File, error) {
+	file, err := f.Fs.Open(name)
+	if err != nil {
+		return nil, err
+	}
+	if f.openWrap != nil {
+		return f.openWrap(file), nil
+	}
+	return file, nil
+}
+
+type sibWriterToTrackingFile struct {
+	File
+	called *bool
+}
+
+func (f *sibWriterToTrackingFile) WriteTo(w io.Writer) (int64, error) {
+	*f.called = true
+	return io.Copy(w, f.File)
+}
+
+// TestRegexpFile_WriteTo_FastPath asserts that io.Copy through a RegexpFs
+// observes the underlying file's io.WriterTo fast path. This is the sibling of
+// PR #577 (BasePathFile). On the UNFIXED tree it FAILS (fast path hidden).
+func TestRegexpFile_WriteTo_FastPath(t *testing.T) {
+	const payload = "hello-regexp-fastpath"
+
+	base := &MemMapFs{}
+	if err := WriteFile(base, "match.txt", []byte(payload), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	called := false
+	tracking := sibOptionalIfaceFs{
+		Fs: base,
+		openWrap: func(file File) File {
+			return &sibWriterToTrackingFile{File: file, called: &called}
+		},
+	}
+
+	rfs := NewRegexpFs(tracking, regexp.MustCompile(`\.txt$`))
+
+	f, err := rfs.Open("match.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	var buf bytes.Buffer
+	n, err := io.Copy(&buf, f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if int(n) != len(payload) || buf.String() != payload {
+		t.Fatalf("copy mismatch: n=%d got=%q", n, buf.String())
+	}
+
+	if !called {
+		t.Fatalf("io.WriterTo fast path NOT taken through RegexpFs (bug reproduced): underlying WriteTo never called")
+	}
+}
+
+// NOTE on the ReadFrom direction: RegexpFs.Create and RegexpFs.OpenFile return
+// the source file UNWRAPPED (they do not produce a *RegexpFile). Only
+// RegexpFs.Open wraps in *RegexpFile. Therefore the io.ReaderFrom-hiding bug is
+// not reachable through RegexpFs today, and a ReadFrom assertion would be
+// vacuous. The sibling fix mirrors PR #577's ReadFrom for interface parity, but
+// the only demonstrable bug is WriteTo (tested above).

--- a/regexpfs.go
+++ b/regexpfs.go
@@ -1,11 +1,17 @@
 package afero
 
 import (
+	"io"
 	"os"
 	"path/filepath"
 	"regexp"
 	"syscall"
 	"time"
+)
+
+var (
+	_ io.WriterTo   = (*RegexpFile)(nil)
+	_ io.ReaderFrom = (*RegexpFile)(nil)
 )
 
 // The RegexpFs filters files (not directories) by regular expression. Only
@@ -160,6 +166,20 @@ func (f *RegexpFile) Close() error {
 
 func (f *RegexpFile) Read(s []byte) (int, error) {
 	return f.f.Read(s)
+}
+
+func (f *RegexpFile) WriteTo(w io.Writer) (int64, error) {
+	if wt, ok := f.f.(io.WriterTo); ok {
+		return wt.WriteTo(w)
+	}
+	return io.Copy(w, f.f)
+}
+
+func (f *RegexpFile) ReadFrom(r io.Reader) (int64, error) {
+	if rf, ok := f.f.(io.ReaderFrom); ok {
+		return rf.ReadFrom(r)
+	}
+	return io.Copy(f.f, r)
 }
 
 func (f *RegexpFile) ReadAt(s []byte, o int64) (int, error) {


### PR DESCRIPTION
#577 fixed `BasePathFile` hiding the underlying file's `io.WriterTo`/`io.ReaderFrom`, which disabled `io.Copy`'s fast paths. Its symmetric sibling `*RegexpFile` (`regexpfs.go`) was left unfixed — `RegexpFs.Open` wraps files with the same delegation pattern but never forwards `WriteTo`, so `io.Copy` from a RegexpFs file loses the fast path.

The fix mirrors #577's method onto `RegexpFile`. Verified both ways: `TestRegexpFile_WriteTo_FastPath` fails on the old tree and passes after; full root suite ok, 0 regression. (ReadFrom is included for interface parity with #577, but `RegexpFs.Create`/`OpenFile` return the source unwrapped so that direction isn't independently reachable today — noted in the diff.)