### PR TITLE
mem: ReadFile returns an error when filename is a directory

### DIFF
--- a/ioutil_test.go
+++ b/ioutil_test.go
@@ -51,6 +51,25 @@ func TestReadFile(t *testing.T) {
 	checkSizePath(t, filename, int64(len(contents)))
 }
 
+func TestReadFileOnDirectory(t *testing.T) {
+	// Regression test for #201: reading a directory as a file must
+	// return an error, like the real os.ReadFile does (EISDIR), instead
+	// of silently succeeding with empty data because an in-memory
+	// directory's data buffer happens to be empty too.
+	testFS = &MemMapFs{}
+	fsutil := &Afero{Fs: testFS}
+
+	dirname := "somedir"
+	if err := testFS.MkdirAll(dirname, 0o755); err != nil {
+		t.Fatalf("MkdirAll %s: %v", dirname, err)
+	}
+
+	contents, err := fsutil.ReadFile(dirname)
+	if err == nil {
+		t.Fatalf("ReadFile %s: error expected, got nil (contents=%q)", dirname, contents)
+	}
+}
+
 func TestWriteFile(t *testing.T) {
 	testFS = &MemMapFs{}
 	fsutil := &Afero{Fs: testFS}

--- a/mem/file.go
+++ b/mem/file.go
@@ -23,6 +23,7 @@ import (
 	"path/filepath"
 	"sync"
 	"sync/atomic"
+	"syscall"
 	"time"
 
 	"github.com/spf13/afero/internal/common"
@@ -218,6 +219,13 @@ func (f *File) ReadAt(b []byte, off int64) (n int, err error) {
 	defer f.fileData.Unlock()
 	if f.closed {
 		return 0, ErrFileClosed
+	}
+	if f.fileData.dir {
+		// Match the real os.File behavior of returning an error when
+		// reading a directory as a file, instead of silently behaving
+		// like an empty file (which an in-memory directory's empty
+		// data buffer would otherwise look like).
+		return 0, &os.PathError{Op: "read", Path: f.fileData.name, Err: syscall.EISDIR}
 	}
 	if len(b) > 0 && int(off) == len(f.fileData.data) {
 		return 0, io.EOF


### PR DESCRIPTION
Fixes #201

## Bug

`afero.ReadFile` on a `MemMapFs` silently succeeds with empty content when the path is a directory, instead of returning an error like the real `os.ReadFile` does (`EISDIR`).

```go
fs := afero.NewMemMapFs()
fs.MkdirAll("/somedir", 0755)
data, err := afero.ReadFile(fs, "/somedir")
// data == "", err == nil  (expected: err != nil)
```

## Root cause

An in-memory directory's `FileData.data` buffer is empty, the same as an empty regular file. `mem.File.ReadAt` had no check for `fileData.dir`, so reading a directory returned `(0, io.EOF)` exactly like reading an empty file would. `File.Read` and `afero.ReadFile`'s underlying `readAll` treat a first `io.EOF` as a normal empty read (not an error), so the whole call chain returns `("", nil)` with no indication anything was wrong.

`Readdir` already has the equivalent inverse check (`if !f.fileData.dir { return error }`), so this brings `ReadAt` in line with that existing convention.

## Fix

Added a directory check at the top of `mem.File.ReadAt` that returns `&os.PathError{Op: "read", Path: ..., Err: syscall.EISDIR}`, matching the real `os.File`'s behavior when `Read` is called on a directory.

Scoped to the read path only (matching the issue title/report) — did not touch `Write`/`WriteAt`, which is a separate question not raised by this issue.

## Tests

Added `TestReadFileOnDirectory` in `ioutil_test.go`, following the existing `TestReadFile` pattern: creates a directory via `MkdirAll`, calls `Afero.ReadFile` on it, and asserts an error is returned.

I verified the test actually catches the regression: temporarily removed the new directory check in `ReadAt` and reran the test — it failed with `ReadFile somedir: error expected, got nil (contents="")`, reproducing the exact symptom from the issue. Restoring the fix makes it pass again.

## Verification

- `go build ./...` — clean
- `go vet ./...` — clean
- `go test ./...` — all pass except `TestLstatIfPossible`/`TestSymlinkIfPossible`/`TestReadlinkIfPossible`, which fail identically on unmodified `master` in my environment (Windows, no privilege to create symlinks) — confirmed pre-existing and unrelated by stashing my changes and rerunning.