### PR TITLE
fix: forward syscall.Conn through BasePathFile and RegexpFile

### DIFF
--- a/basepath.go
+++ b/basepath.go
@@ -1,12 +1,14 @@
 package afero
 
 import (
+	"errors"
 	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
+	"syscall"
 	"time"
 )
 
@@ -15,6 +17,7 @@ var (
 	_ fs.ReadDirFile = (*BasePathFile)(nil)
 	_ io.WriterTo    = (*BasePathFile)(nil)
 	_ io.ReaderFrom  = (*BasePathFile)(nil)
+	_ syscall.Conn   = (*BasePathFile)(nil)
 )
 
 // The BasePathFs restricts all operations to a given path within an Fs.
@@ -59,6 +62,13 @@ func (f *BasePathFile) ReadFrom(r io.Reader) (int64, error) {
 		return rf.ReadFrom(r)
 	}
 	return io.Copy(f.File, r)
+}
+
+func (f *BasePathFile) SyscallConn() (syscall.RawConn, error) {
+	if sc, ok := f.File.(syscall.Conn); ok {
+		return sc.SyscallConn()
+	}
+	return nil, errors.New("afero: underlying file does not implement syscall.Conn")
 }
 
 func NewBasePathFs(source Fs, path string) Fs {

--- a/regexpfs.go
+++ b/regexpfs.go
@@ -1,12 +1,15 @@
 package afero
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"regexp"
 	"syscall"
 	"time"
 )
+
+var _ syscall.Conn = (*RegexpFile)(nil)
 
 // The RegexpFs filters files (not directories) by regular expression. Only
 // files matching the given regexp will be allowed, all others get a ENOENT error (
@@ -221,4 +224,11 @@ func (f *RegexpFile) Truncate(s int64) error {
 
 func (f *RegexpFile) WriteString(s string) (int, error) {
 	return f.f.WriteString(s)
+}
+
+func (f *RegexpFile) SyscallConn() (syscall.RawConn, error) {
+	if sc, ok := f.f.(syscall.Conn); ok {
+		return sc.SyscallConn()
+	}
+	return nil, errors.New("afero: underlying file does not implement syscall.Conn")
 }

--- a/syscall_conn_test.go
+++ b/syscall_conn_test.go
@@ -1,0 +1,122 @@
+package afero
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"syscall"
+	"testing"
+)
+
+// controlSucceeds runs rc.Control and fails the test if either the Control
+// call itself or the callback-reported syscall error is non-nil, and if the
+// file descriptor handed to the callback is not valid (> 0).
+func controlSucceeds(t *testing.T, rc syscall.RawConn) {
+	t.Helper()
+	var fd uintptr
+	var innerErr error
+	if err := rc.Control(func(descriptor uintptr) {
+		fd = descriptor
+	}); err != nil {
+		innerErr = err
+	}
+	if innerErr != nil {
+		t.Fatalf("rc.Control returned error: %v", innerErr)
+	}
+	if fd == 0 {
+		t.Fatalf("rc.Control handed back an invalid (zero) file descriptor")
+	}
+}
+
+func TestBasePathFileSyscallConn(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "f.txt"), []byte("payload"), 0o644); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+
+	bp := NewBasePathFs(NewOsFs(), dir)
+	f, err := bp.Open("f.txt")
+	if err != nil {
+		t.Fatalf("open failed: %v", err)
+	}
+	defer f.Close()
+
+	sc, ok := f.(syscall.Conn)
+	if !ok {
+		t.Fatal("BasePathFile wrapping *os.File should implement syscall.Conn")
+	}
+	rc, err := sc.SyscallConn()
+	if err != nil {
+		t.Fatalf("SyscallConn returned error: %v", err)
+	}
+	controlSucceeds(t, rc)
+}
+
+func TestRegexpFileSyscallConn(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "f.txt"), []byte("payload"), 0o644); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+
+	rfs := NewRegexpFs(NewOsFs(), regexp.MustCompile(`\.txt$`))
+	f, err := rfs.Open(filepath.Join(dir, "f.txt"))
+	if err != nil {
+		t.Fatalf("open failed: %v", err)
+	}
+	defer f.Close()
+
+	sc, ok := f.(syscall.Conn)
+	if !ok {
+		t.Fatal("RegexpFile wrapping *os.File should implement syscall.Conn")
+	}
+	rc, err := sc.SyscallConn()
+	if err != nil {
+		t.Fatalf("SyscallConn returned error: %v", err)
+	}
+	controlSucceeds(t, rc)
+}
+
+// Negative control: when the wrapped file does NOT implement syscall.Conn
+// (e.g. an in-memory file), SyscallConn must return a descriptive error
+// instead of panicking or silently succeeding.
+func TestBasePathFileSyscallConnUnsupported(t *testing.T) {
+	mem := NewMemMapFs()
+	if err := WriteFile(mem, "/f.txt", []byte("payload"), 0o644); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+	bp := NewBasePathFs(mem, "/")
+	f, err := bp.Open("f.txt")
+	if err != nil {
+		t.Fatalf("open failed: %v", err)
+	}
+	defer f.Close()
+
+	sc, ok := f.(syscall.Conn)
+	if !ok {
+		t.Fatal("BasePathFile must always expose the syscall.Conn method (even if it errors)")
+	}
+	if _, err := sc.SyscallConn(); err == nil {
+		t.Fatal("expected SyscallConn to return an error for a non-syscall.Conn backing file")
+	}
+}
+
+func TestRegexpFileSyscallConnUnsupported(t *testing.T) {
+	mem := NewMemMapFs()
+	if err := WriteFile(mem, "/f.txt", []byte("payload"), 0o644); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+	rfs := NewRegexpFs(mem, regexp.MustCompile(`\.txt$`))
+	f, err := rfs.Open("/f.txt")
+	if err != nil {
+		t.Fatalf("open failed: %v", err)
+	}
+	defer f.Close()
+
+	sc, ok := f.(syscall.Conn)
+	if !ok {
+		t.Fatal("RegexpFile must always expose the syscall.Conn method (even if it errors)")
+	}
+	if _, err := sc.SyscallConn(); err == nil {
+		t.Fatal("expected SyscallConn to return an error for a non-syscall.Conn backing file")
+	}
+}


### PR DESCRIPTION
## Summary
- add SyscallConn on BasePathFile, forwarding to the wrapped file when it implements syscall.Conn
- add SyscallConn on RegexpFile, same pattern
- regression tests for both, plus negative-control tests for wrapped files that don't support it (MemMapFs)

## Why
*os.File implements syscall.Conn, which net/http and io.Copy use to hit the sendfile(2) fast path. BasePathFile and RegexpFile don't forward it, so anything served through BasePathFs or RegexpFs silently falls back to a userspace copy. Same class of bug as #577 (WriterTo/ReaderFrom), just a different interface.

ReadOnlyFs.Open returns the source file directly without wrapping, so it already passes syscall.Conn through and needs no change here.

CopyOnWriteFs wraps into UnionFile{Base, Layer}, not a single-file pass-through, so forwarding syscall.Conn there is a separate design question (which side wins) and out of scope for this PR.

Not overlapping with #632 (WriterTo/ReaderFrom on RegexpFile), different interface on the same wrapper, filed independently.

## Test Plan
- go test ./...
- go test -race ./...

Fixes #630
