### PR TITLE
Fix discarded base Open error in CacheOnReadFs.Open (#116)

### DIFF
--- a/cacheOnReadFs.go
+++ b/cacheOnReadFs.go
@@ -271,10 +271,22 @@ func (u *CacheOnReadFs) Open(name string) (File, error) {
 		}
 	}
 	// the dirs from cacheHit, cacheStale fall down here:
-	bfile, _ := u.base.Open(name)
-	lfile, err := u.layer.Open(name)
-	if err != nil && bfile == nil {
-		return nil, err
+	bfile, bErr := u.base.Open(name)
+	lfile, lErr := u.layer.Open(name)
+
+	// A failed Open may still hand back a non-nil but unusable File; never
+	// wrap such a handle in the UnionFile, as it panics on use (see #116).
+	if bErr != nil {
+		bfile = nil
+	}
+	if lErr != nil {
+		lfile = nil
+	}
+
+	// If neither the base nor the layer yielded a usable file, surface the
+	// error instead of returning a broken UnionFile.
+	if bfile == nil && lfile == nil {
+		return nil, lErr
 	}
 	return &UnionFile{Base: bfile, Layer: lfile}, nil
 }

--- a/composite_test.go
+++ b/composite_test.go
@@ -515,3 +515,92 @@ func TestUnionFileReaddirAskForTooMany(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+// faultyOpenBaseFs is a base Fs whose Open returns a non-nil but unusable File
+// together with an error, simulating a filesystem that hands back a bad handle.
+// It embeds MemMapFs so cacheStatus/Stat behave normally.
+type faultyOpenBaseFs struct {
+	MemMapFs
+}
+
+// invalidReaddirFile is a File whose Readdir panics, standing in for the
+// unusable handle a faulty Open may return.
+type invalidReaddirFile struct {
+	File
+}
+
+func (invalidReaddirFile) Readdir(int) ([]os.FileInfo, error) {
+	panic("Readdir called on an invalid base file handle")
+}
+
+func (f *faultyOpenBaseFs) Open(name string) (File, error) {
+	return invalidReaddirFile{}, os.ErrPermission
+}
+
+// #116: CacheOnReadFs.Open discarded the error from base.Open and wrapped the
+// (possibly non-nil but invalid) base handle in a UnionFile, which panics or
+// silently corrupts on use. Opening a directory that exists in the layer while
+// the base Open fails must not wrap the bad handle.
+func TestCacheOnReadFsOpenFaultyBaseDir(t *testing.T) {
+	layer := NewMemMapFs()
+	if err := layer.MkdirAll("/dir", 0o777); err != nil {
+		t.Fatal(err)
+	}
+	fh, err := layer.Create("/dir/a.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	fh.Close()
+
+	ufs := NewCacheOnReadFs(&faultyOpenBaseFs{}, layer, 0)
+
+	f, err := ufs.Open("/dir")
+	if err != nil {
+		t.Fatalf("Open of a layer-readable dir should succeed, got error: %v", err)
+	}
+	uf, ok := f.(*UnionFile)
+	if !ok {
+		t.Fatalf("expected *UnionFile, got %T", f)
+	}
+	if uf.Base != nil {
+		t.Fatal("failed base handle wrapped in UnionFile.Base; would panic on use (#116)")
+	}
+
+	// Must not panic and must return the layer's entries.
+	names, err := f.Readdirnames(-1)
+	if err != nil {
+		t.Fatalf("Readdirnames failed: %v", err)
+	}
+	if len(names) != 1 || names[0] != "a.txt" {
+		t.Fatalf("expected [a.txt] from the layer, got %v", names)
+	}
+}
+
+// #116 (non-regression): a directory that exists only in the layer must still
+// open as a UnionFile backed solely by the layer — the fix must not turn a
+// missing base into a hard error.
+func TestCacheOnReadFsOpenLayerOnlyDir(t *testing.T) {
+	base := NewMemMapFs()
+	layer := NewMemMapFs()
+	if err := layer.MkdirAll("/onlylayer", 0o777); err != nil {
+		t.Fatal(err)
+	}
+	fh, err := layer.Create("/onlylayer/a.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	fh.Close()
+
+	ufs := NewCacheOnReadFs(base, layer, 0)
+	f, err := ufs.Open("/onlylayer")
+	if err != nil {
+		t.Fatalf("Open of layer-only dir should succeed, got: %v", err)
+	}
+	names, err := f.Readdirnames(-1)
+	if err != nil {
+		t.Fatalf("Readdirnames failed: %v", err)
+	}
+	if len(names) != 1 || names[0] != "a.txt" {
+		t.Fatalf("expected [a.txt], got %v", names)
+	}
+}


### PR DESCRIPTION
## Fix silent base-Open error in `CacheOnReadFs.Open` (#116)

### Problem

`CacheOnReadFs.Open()` discarded the error returned by `u.base.Open(name)`:

```go
bfile, _ := u.base.Open(name)
lfile, err := u.layer.Open(name)
if err != nil && bfile == nil {
    return nil, err
}
return &UnionFile{Base: bfile, Layer: lfile}, nil
```

When the base `Open` fails, some `Fs` implementations return a **non-nil but
unusable** `File` alongside the error. Because the code only inspected the
layer error and used `bfile == nil` as its guard, that bad handle was wrapped
into the returned `UnionFile.Base`. `UnionFile` only nil-checks the interface,
not its validity — so a later `Readdir` / `Read` call on the union dereferences
the invalid base handle and panics (or silently corrupts the merged result).

### Root cause

`cacheOnReadFs.go`, `(*CacheOnReadFs).Open`, the directory fall-through at the
end of the method (original lines 273–279). The base `Open` error was thrown
away, and the `bfile == nil` proxy for "no base file" is unreliable for
filesystems that hand back a non-nil handle on error.

### Fix

Capture both errors. If an `Open` returns an error, treat that side as absent
(never wrap its handle). Only surface an error when **neither** the base nor
the layer produced a usable file:

```go
bfile, bErr := u.base.Open(name)
lfile, lErr := u.layer.Open(name)

if bErr != nil {
    bfile = nil
}
if lErr != nil {
    lfile = nil
}

if bfile == nil && lfile == nil {
    return nil, lErr
}
return &UnionFile{Base: bfile, Layer: lfile}, nil
```

**Why not a hard fail-fast on either error** (as the sibling
`CopyOnWriteFs.Open` does)? `CopyOnWriteFs.Open` reaches its `UnionFile`
construction only after an explicit `IsDir(u.base, name)` check guarantees the
base holds a readable directory, so a base `Open` failure there really is
"something is very wrong." `CacheOnReadFs.Open` has no such guard: with
`cacheTime == 0`, a directory that exists **only in the layer** is classified
as `cacheHit` and falls through to this same code, where `u.base.Open` legitimately
fails with "not exist." Failing the whole `Open` in that case would regress a
valid, currently-working union scenario (verified — see tests). The fix
therefore keeps the union's tolerance of a missing/failed base while refusing
to wrap an invalid handle.

### Tests

Added to `composite_test.go`:

- `TestCacheOnReadFsOpenFaultyBaseDir` — a mock base whose `Open` returns a
  non-nil, `Readdir`-panicking `File` plus `os.ErrPermission`, with the
  directory present in the layer. Asserts `Open` succeeds, `UnionFile.Base`
  is `nil` (the bad handle is not wrapped), and `Readdirnames` returns the
  layer entries without panicking. **Fails before the fix** (bad handle
  wrapped) and **passes after**.
- `TestCacheOnReadFsOpenLayerOnlyDir` — non-regression guard: a directory that
  exists only in the layer still opens and lists correctly, proving the fix
  does not turn a legitimately-absent base into a hard error.

### Verification

```
# Before fix (regression test):
--- FAIL: TestCacheOnReadFsOpenFaultyBaseDir
    composite_test.go: failed base handle wrapped in UnionFile.Base; would panic on use (#116)

# After fix:
--- PASS: TestCacheOnReadFsOpenFaultyBaseDir
--- PASS: TestCacheOnReadFsOpenLayerOnlyDir

go test -race ./...   -> ok (all packages)
go vet ./...          -> clean
gofmt -l <changed>    -> clean
golangci-lint run     -> no new findings in changed files
```

### Compatibility

No API or signature changes. Behavior is unchanged for every previously-working
case (both-open-succeed, base-only, layer-only). The only behavioral change is
that a base `Open` returning an invalid non-nil handle no longer produces a
panicking `UnionFile`, and an `Open` where both sides fail now returns the error
instead of a broken union.

Fixes #116
