### PR TITLE
fix(basepath): strip leading-slash relative bases in File.Name

### DIFF
--- a/basepath.go
+++ b/basepath.go
@@ -37,7 +37,34 @@ type BasePathFile struct {
 
 func (f *BasePathFile) Name() string {
 	sourcename := f.File.Name()
-	return strings.TrimPrefix(sourcename, filepath.Clean(f.path))
+	base := filepath.Clean(f.path)
+	if base == "." {
+		return sourcename
+	}
+	// Historical path: strip Clean(base) when it is an exact prefix.
+	if strings.HasPrefix(sourcename, base) {
+		if len(sourcename) == len(base) {
+			return string(filepath.Separator)
+		}
+		if sourcename[len(base)] == filepath.Separator || strings.HasSuffix(base, string(filepath.Separator)) {
+			return sourcename[len(base):]
+		}
+	}
+	// Nested BasePathFs often yields a leading separator in front of a
+	// relative base, e.g. base "123" and name "/123/file". filepath.Clean
+	// drops a trailing slash on the base, so TrimPrefix alone misses it.
+	if !filepath.IsAbs(base) {
+		sepBase := string(filepath.Separator) + base
+		if strings.HasPrefix(sourcename, sepBase) {
+			if len(sourcename) == len(sepBase) {
+				return string(filepath.Separator)
+			}
+			if sourcename[len(sepBase)] == filepath.Separator {
+				return sourcename[len(sepBase):]
+			}
+		}
+	}
+	return sourcename
 }
 
 func (f *BasePathFile) ReadDir(n int) ([]fs.DirEntry, error) {

--- a/basepath_test.go
+++ b/basepath_test.go
@@ -3,6 +3,7 @@ package afero
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"runtime"
 	"testing"
 )
@@ -305,5 +306,49 @@ func TestBasePathTempFile(t *testing.T) {
 	defer tempFile.Close()
 	if expected, actual := tDir, filepath.Dir(tempFile.Name()); expected != actual {
 		t.Fatalf("TempFile realpath leaked: expected %s, got %s", expected, actual)
+	}
+}
+
+
+func TestNestedBasePathFileName(t *testing.T) {
+	// Nested relative bases must strip each layer so File.Name can be reused
+	// with Chmod/Stat/etc. (https://github.com/spf13/afero/issues/428).
+	mem := NewMemMapFs()
+	level1 := NewBasePathFs(mem, "files")
+	level2 := NewBasePathFs(level1, "123")
+	if err := level2.MkdirAll(".", 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	f, err := TempFile(level2, ".", "afero-test-*")
+	if err != nil {
+		t.Fatalf("TempFile: %v", err)
+	}
+	defer f.Close()
+
+	name := f.Name()
+	if strings.Contains(name, "files") || strings.HasPrefix(strings.TrimPrefix(name, string(filepath.Separator)), "123"+string(filepath.Separator)) {
+		// Name should not retain outer base segments that RealPath will re-join.
+	}
+	// Stronger: Chmod via Name must succeed (bug was ENOENT from double-joining).
+	if err := level2.Chmod(name, 0o400); err != nil {
+		t.Fatalf("Chmod(%q): %v (name leaked outer base?)", name, err)
+	}
+	if _, err := level2.Stat(name); err != nil {
+		t.Fatalf("Stat(%q): %v", name, err)
+	}
+
+	// Absolute base still strips cleanly.
+	baseFs := NewMemMapFs()
+	if err := baseFs.MkdirAll("/base/path/tmp", 0o777); err != nil {
+		t.Fatal(err)
+	}
+	bp := NewBasePathFs(baseFs, "/base/path")
+	af, err := bp.Create("/tmp/file.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer af.Close()
+	if got, want := af.Name(), filepath.Clean("/tmp/file.txt"); got != want {
+		t.Fatalf("absolute base Name: got %q want %q", got, want)
 	}
 }


### PR DESCRIPTION
## Summary
`BasePathFile.Name()` used `strings.TrimPrefix(name, filepath.Clean(base))`.
When a relative base is nested, the underlying name often looks like `/123/file`
while `Clean("123")` is `123`, so the prefix never matched.

That leaked the outer base into `Name()`, and follow-up ops like `Chmod(f.Name())`
double-joined the path and returned `ENOENT`.

## Fix
Also strip `"/"+Clean(base)` when the base is relative, while keeping the
historical absolute-base stripping used by existing tests.

## Test plan
- [x] `go test .`
- [x] `TestNestedBasePathFileName` (nested relative bases + absolute base)

Fixes #428
