### PR TITLE
docs: fix comment typos in gcsfs and sftpfs

### DIFF
--- a/gcsfs/file_resource.go
+++ b/gcsfs/file_resource.go
@@ -33,8 +33,8 @@ const (
 
 // gcsFileResource represents a singleton version of each GCS object;
 // Google cloud storage allows users to open multiple writers(!) to the same
-// underlying resource, once the write is closed the written stream is commented. We are doing
-// some magic where we read and and write to the same file which requires synchronization
+// underlying resource, once the write is closed the written stream is committed. We are doing
+// some magic where we read and write to the same file which requires synchronization
 // of the underlying resource.
 
 type gcsFileResource struct {

--- a/sftpfs/sftp.go
+++ b/sftpfs/sftp.go
@@ -25,7 +25,7 @@ import (
 
 var _ afero.Symlinker = (*Fs)(nil)
 
-// Fs is a afero.Fs implementation that uses functions provided by the sftp package.
+// Fs is an afero.Fs implementation that uses functions provided by the sftp package.
 //
 // For details in any method, check the documentation of the sftp package
 // (github.com/pkg/sftp).


### PR DESCRIPTION
## Summary
Fix a few comment typos:

- gcsfs: "read and and write" → "read and write"
- gcsfs: "written stream is commented" → "committed" (GCS object write close)
- sftpfs: "a afero.Fs" → "an afero.Fs"

No behavior changes.

## Test plan
- [x] `go test .`