### PR TITLE
fix: nil BasePathFs doesn't panic on Stat

### DIFF
--- a/basepath.go
+++ b/basepath.go
@@ -68,6 +68,9 @@ func NewBasePathFs(source Fs, path string) Fs {
 // on a file outside the base path it returns the given file name and an error,
 // else the given file with the base path prepended
 func (b *BasePathFs) RealPath(name string) (path string, err error) {
+	if b == nil {
+		return name, &os.PathError{Op: "realpath", Path: name, Err: os.ErrInvalid}
+	}
 	if err := validateBasePathName(name); err != nil {
 		return name, err
 	}

--- a/nil_basepath_test.go
+++ b/nil_basepath_test.go
@@ -1,0 +1,16 @@
+package afero
+
+import "testing"
+
+func TestNilBasePathFsStat(t *testing.T) {
+	var b *BasePathFs
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("panicked: %v", r)
+		}
+	}()
+	_, err := b.Stat("x")
+	if err == nil {
+		t.Fatal("want error")
+	}
+}


### PR DESCRIPTION
```go
var b *afero.BasePathFs
b.Stat("x") // panic
```

RealPath returns a PathError when the receiver is nil.