### PR TITLE
fix: reject empty path in ReadFile and WriteFile

### DIFF
--- a/empty_path_test.go
+++ b/empty_path_test.go
@@ -1,0 +1,23 @@
+package afero
+
+import (
+	"errors"
+	"os"
+	"testing"
+)
+
+func TestWriteReadFileEmptyPath(t *testing.T) {
+	fs := NewMemMapFs()
+	if err := WriteFile(fs, "", []byte("x"), 0o644); err == nil {
+		t.Fatal("expected write error")
+	} else if !errors.Is(err, os.ErrInvalid) {
+		// PathError may wrap
+		var pe *os.PathError
+		if !errors.As(err, &pe) {
+			t.Fatalf("got %v", err)
+		}
+	}
+	if _, err := ReadFile(fs, ""); err == nil {
+		t.Fatal("expected read error")
+	}
+}

--- a/ioutil.go
+++ b/ioutil.go
@@ -64,6 +64,9 @@ func (a Afero) ReadFile(filename string) ([]byte, error) {
 }
 
 func ReadFile(fs Fs, filename string) ([]byte, error) {
+	if filename == "" {
+		return nil, &os.PathError{Op: "read", Path: filename, Err: os.ErrInvalid}
+	}
 	f, err := fs.Open(filename)
 	if err != nil {
 		return nil, err
@@ -124,6 +127,9 @@ func (a Afero) WriteFile(filename string, data []byte, perm os.FileMode) error {
 }
 
 func WriteFile(fs Fs, filename string, data []byte, perm os.FileMode) error {
+	if filename == "" {
+		return &os.PathError{Op: "write", Path: filename, Err: os.ErrInvalid}
+	}
 	f, err := fs.OpenFile(filename, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, perm)
 	if err != nil {
 		return err


### PR DESCRIPTION
## What

`ReadFile` / `WriteFile` reject empty filenames with `os.PathError` / `os.ErrInvalid`.

## Why

Matches `os` package behavior and avoids surprising operations on an empty path.

## Test

- `TestWriteReadFileEmptyPath`