### PR TITLE
docs,feat: improve FromIOFS for embed.FS (#337)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Afero elevates filesystem interaction beyond simple file reading and writing, of
     *   **Caching:** Use `CacheOnReadFs` to automatically layer a fast cache (like memory) over a slow backend (like a network drive).
     *   **Security Jails:** Use `BasePathFs` to restrict application access to a specific subdirectory (chroot).
 *   **`os` Package Compatibility:** Afero mirrors the functions in the standard `os` package, making adoption and refactoring seamless.
-*   **`io/fs` Compatibility:** Fully compatible with the Go standard library's `io/fs` interfaces.
+*   **`io/fs` Compatibility:** Fully compatible with the Go standard library's `io/fs` interfaces in both directions—export any Afero filesystem as `fs.FS` with `NewIOFS`, or import any `fs.FS` (including `embed.FS`) with `NewFromIOFS`.
 
 ## Installation
 
@@ -50,6 +50,7 @@ import "github.com/spf13/afero"
 | | **ReadOnlyFs** | `afero.NewReadOnlyFs(source)` | Provides a read-only view, preventing any modifications. | ✅ Official |
 | | **RegexpFs** | `afero.NewRegexpFs(source, regexp)` | Filters a filesystem, only showing files that match a regex. | ✅ Official |
 | **Utility** | **HttpFs** | `afero.NewHttpFs(source)` | Wraps any Afero filesystem to be served via `http.FileServer`. | ✅ Official |
+| | **FromIOFS** | `afero.NewFromIOFS(fsys)` | Adapts any `io/fs.FS` (e.g. `embed.FS`, `fstest.MapFS`) as a read-only Afero filesystem. | ✅ Official |
 | **Archives** | **ZipFs** | `zipfs.New(zipReader)` | Read-only access to files within a ZIP archive. | ✅ Official |
 | | **TarFs** | `tarfs.New(tarReader)` | Read-only access to files within a TAR archive. | ✅ Official |
 | **Network** | **GcsFs** | `gcsfs.NewGcsFs(...)` | Google Cloud Storage backend. | ⚡ Experimental |
@@ -332,16 +333,23 @@ Afero complements `io/fs` by focusing on different needs:
     *   You need to test complex read/write interactions (e.g., renaming, concurrent writes).
     *   You need advanced compositional features (Copy-on-Write, Caching, etc.).
 
-Afero is fully compatible with `io/fs`. You can wrap any Afero filesystem to satisfy the `fs.FS` interface using `afero.NewIOFS`:
+Afero is fully compatible with `io/fs` in both directions:
 
 ```go
-import "io/fs"
+import (
+    "embed"
+    "io/fs"
+    "github.com/spf13/afero"
+)
 
-// Create an Afero filesystem (writable)
+// Afero Fs → standard library fs.FS (read-only view)
 var myAferoFs afero.Fs = afero.NewMemMapFs()
-
-// Convert it to a standard library fs.FS (read-only view)
 var myIoFs fs.FS = afero.NewIOFS(myAferoFs)
+
+// standard library fs.FS (e.g. embed.FS) → Afero Fs (read-only)
+//go:embed assets/*
+var assetsFS embed.FS
+var fromEmbed afero.Fs = afero.NewFromIOFS(assetsFS)
 ```
 
 ## Third-Party Backends & Ecosystem
@@ -433,7 +441,7 @@ Mount any Afero filesystem as a Windows drive letter. Brilliant demonstration of
 
 ### Modern Asset Embedding (Go 1.16+)
 
-Instead of third-party tools, use Go's native `//go:embed` with Afero:
+Use Go's native `//go:embed` with Afero via `NewFromIOFS`. The resulting filesystem is read-only; layer a `CopyOnWriteFs` if you need runtime overrides:
 
 ```go
 import (
@@ -445,11 +453,15 @@ import (
 var assetsFS embed.FS
 
 func main() {
-    // Convert embedded files to Afero filesystem
-    fs := afero.FromIOFS(assetsFS)
-    
+    // Convert embedded files to a read-only Afero filesystem
+    base := afero.NewFromIOFS(assetsFS)
+
     // Use like any other Afero filesystem
-    content, _ := afero.ReadFile(fs, "assets/config.json")
+    content, _ := afero.ReadFile(base, "assets/config.json")
+
+    // Optional: writable overlay so runtime changes do not touch embed.FS
+    fs := afero.NewCopyOnWriteFs(base, afero.NewMemMapFs())
+    _ = afero.WriteFile(fs, "assets/config.json", []byte(`{"env":"dev"}`), 0644)
 }
 ```
 

--- a/iofs.go
+++ b/iofs.go
@@ -150,11 +150,27 @@ func (r readDirFile) ReadDir(n int) ([]fs.DirEntry, error) {
 	return ret, nil
 }
 
-// FromIOFS adopts io/fs.FS to use it as afero.Fs
-// Note that io/fs.FS is read-only so all mutating methods will return fs.PathError with fs.ErrPermission
-// To store modifications you may use afero.CopyOnWriteFs
+// FromIOFS adopts io/fs.FS to use it as afero.Fs.
+//
+// Note that io/fs.FS is read-only so all mutating methods will return
+// *fs.PathError with fs.ErrPermission. To store modifications you may use
+// afero.CopyOnWriteFs with FromIOFS as the base.
+//
+// FromIOFS is the standard way to use embed.FS (or any other fs.FS) with
+// libraries that expect an afero.Fs, for example:
+//
+//	//go:embed assets/*
+//	var assetsFS embed.FS
+//	fs := afero.NewFromIOFS(assetsFS)
+//	data, err := afero.ReadFile(fs, "assets/config.json")
 type FromIOFS struct {
 	fs.FS
+}
+
+// NewFromIOFS creates a read-only afero.Fs from any io/fs.FS implementation,
+// including embed.FS and testing/fstest.MapFS.
+func NewFromIOFS(fsys fs.FS) Fs {
+	return FromIOFS{FS: fsys}
 }
 
 var _ Fs = FromIOFS{}
@@ -182,6 +198,10 @@ func (f FromIOFS) Open(name string) (File, error) {
 }
 
 func (f FromIOFS) OpenFile(name string, flag int, perm os.FileMode) (File, error) {
+	// io/fs.FS is read-only; reject any write-oriented flags.
+	if flag&(os.O_WRONLY|os.O_RDWR|os.O_APPEND|os.O_CREATE|os.O_TRUNC) != 0 {
+		return nil, notImplemented("open", name)
+	}
 	return f.Open(name)
 }
 

--- a/iofs_test.go
+++ b/iofs_test.go
@@ -5,6 +5,7 @@ package afero
 
 import (
 	"bytes"
+	"embed"
 	"errors"
 	"fmt"
 	"io"
@@ -19,6 +20,9 @@ import (
 
 	"github.com/spf13/afero/internal/common"
 )
+
+//go:embed testdata/fromiofs
+var fromIOFSEmbedFS embed.FS
 
 func TestIOFS(t *testing.T) {
 	if runtime.GOOS == "windows" {
@@ -187,7 +191,7 @@ func TestFromIOFS(t *testing.T) {
 		},
 	}
 
-	fromIOFS := FromIOFS{fsys}
+	fromIOFS := NewFromIOFS(fsys)
 
 	t.Run("Create", func(t *testing.T) {
 		_, err := fromIOFS.Create("test")
@@ -200,7 +204,35 @@ func TestFromIOFS(t *testing.T) {
 	})
 
 	t.Run("MkdirAll", func(t *testing.T) {
-		err := fromIOFS.Mkdir("test", 0)
+		err := fromIOFS.MkdirAll("test", 0)
+		assertPermissionError(t, err)
+	})
+
+	t.Run("OpenFile write flags", func(t *testing.T) {
+		for _, flag := range []int{os.O_WRONLY, os.O_RDWR, os.O_APPEND, os.O_CREATE, os.O_TRUNC} {
+			_, err := fromIOFS.OpenFile("test.txt", flag, 0)
+			assertPermissionError(t, err)
+		}
+	})
+
+	t.Run("OpenFile read-only", func(t *testing.T) {
+		file, err := fromIOFS.OpenFile("test.txt", os.O_RDONLY, 0)
+		if err != nil {
+			t.Fatalf("OpenFile O_RDONLY failed: %v", err)
+		}
+		defer file.Close()
+
+		data, err := io.ReadAll(file)
+		if err != nil {
+			t.Fatalf("ReadAll failed: %v", err)
+		}
+		if expected := fsys["test.txt"].Data; !bytes.Equal(data, expected) {
+			t.Errorf("unexpected content: got %q, want %q", data, expected)
+		}
+	})
+
+	t.Run("RemoveAll", func(t *testing.T) {
+		err := fromIOFS.RemoveAll("test")
 		assertPermissionError(t, err)
 	})
 
@@ -344,7 +376,7 @@ func TestFromIOFS_File(t *testing.T) {
 		},
 	}
 
-	fromIOFS := FromIOFS{fsys}
+	fromIOFS := NewFromIOFS(fsys)
 
 	file, err := fromIOFS.Open("test.txt")
 	if err != nil {
@@ -529,6 +561,109 @@ func TestFromIOFS_File(t *testing.T) {
 	})
 }
 
+func TestFromIOFS_EmbedFS(t *testing.T) {
+	t.Parallel()
+
+	fsys := NewFromIOFS(fromIOFSEmbedFS)
+
+	t.Run("ReadFile hello", func(t *testing.T) {
+		data, err := ReadFile(fsys, "testdata/fromiofs/hello.txt")
+		if err != nil {
+			t.Fatalf("ReadFile failed: %v", err)
+		}
+		if expected := []byte("hello from embed\n"); !bytes.Equal(data, expected) {
+			t.Errorf("unexpected content: got %q, want %q", data, expected)
+		}
+	})
+
+	t.Run("ReadFile nested", func(t *testing.T) {
+		data, err := ReadFile(fsys, "testdata/fromiofs/subdir/nested.txt")
+		if err != nil {
+			t.Fatalf("ReadFile failed: %v", err)
+		}
+		if expected := []byte("nested content\n"); !bytes.Equal(data, expected) {
+			t.Errorf("unexpected content: got %q, want %q", data, expected)
+		}
+	})
+
+	t.Run("Stat", func(t *testing.T) {
+		info, err := fsys.Stat("testdata/fromiofs/hello.txt")
+		if err != nil {
+			t.Fatalf("Stat failed: %v", err)
+		}
+		if info.IsDir() {
+			t.Error("expected file, got directory")
+		}
+		if info.Size() != int64(len("hello from embed\n")) {
+			t.Errorf("unexpected size: got %d", info.Size())
+		}
+	})
+
+	t.Run("ReadDir", func(t *testing.T) {
+		dir, err := fsys.Open("testdata/fromiofs")
+		if err != nil {
+			t.Fatalf("Open dir failed: %v", err)
+		}
+		defer dir.Close()
+
+		names, err := dir.Readdirnames(-1)
+		if err != nil {
+			t.Fatalf("Readdirnames failed: %v", err)
+		}
+
+		want := map[string]bool{"hello.txt": true, "subdir": true}
+		if len(names) != len(want) {
+			t.Fatalf("unexpected entries %v", names)
+		}
+		for _, name := range names {
+			if !want[name] {
+				t.Errorf("unexpected entry %q", name)
+			}
+		}
+	})
+
+	t.Run("mutators rejected", func(t *testing.T) {
+		assertPermissionError(t, fsys.Mkdir("x", 0o755))
+		assertPermissionError(t, fsys.Remove("testdata/fromiofs/hello.txt"))
+		_, err := fsys.Create("testdata/fromiofs/new.txt")
+		assertPermissionError(t, err)
+	})
+
+	t.Run("CopyOnWrite overlay", func(t *testing.T) {
+		cow := NewCopyOnWriteFs(fsys, NewMemMapFs())
+
+		// Base content still readable.
+		data, err := ReadFile(cow, "testdata/fromiofs/hello.txt")
+		if err != nil {
+			t.Fatalf("ReadFile base failed: %v", err)
+		}
+		if expected := []byte("hello from embed\n"); !bytes.Equal(data, expected) {
+			t.Errorf("unexpected base content: got %q, want %q", data, expected)
+		}
+
+		// Writes go to the overlay; embed remains read-only.
+		if err := WriteFile(cow, "testdata/fromiofs/hello.txt", []byte("override\n"), 0o644); err != nil {
+			t.Fatalf("WriteFile overlay failed: %v", err)
+		}
+		data, err = ReadFile(cow, "testdata/fromiofs/hello.txt")
+		if err != nil {
+			t.Fatalf("ReadFile overlay failed: %v", err)
+		}
+		if expected := []byte("override\n"); !bytes.Equal(data, expected) {
+			t.Errorf("unexpected overlay content: got %q, want %q", data, expected)
+		}
+
+		// Underlying embed FS is unchanged.
+		baseData, err := ReadFile(fsys, "testdata/fromiofs/hello.txt")
+		if err != nil {
+			t.Fatalf("ReadFile base after write failed: %v", err)
+		}
+		if expected := []byte("hello from embed\n"); !bytes.Equal(baseData, expected) {
+			t.Errorf("embed content mutated: got %q, want %q", baseData, expected)
+		}
+	})
+}
+
 func assertPermissionError(t *testing.T, err error) {
 	t.Helper()
 
@@ -538,8 +673,8 @@ func assertPermissionError(t *testing.T, err error) {
 		return
 	}
 
-	if perr.Err != fs.ErrPermission {
-		t.Errorf("Expected (*fs.PathError).Err == fs.ErrPermisson, got %[1]T (%[1]v)", err)
+	if !errors.Is(perr.Err, fs.ErrPermission) {
+		t.Errorf("Expected (*fs.PathError).Err == fs.ErrPermission, got %[1]T (%[1]v)", err)
 	}
 }
 

--- a/testdata/fromiofs/hello.txt
+++ b/testdata/fromiofs/hello.txt
@@ -1,0 +1,1 @@
+hello from embed

--- a/testdata/fromiofs/subdir/nested.txt
+++ b/testdata/fromiofs/subdir/nested.txt
@@ -1,0 +1,1 @@
+nested content


### PR DESCRIPTION
## Summary

`FromIOFS` has wrapped any `io/fs.FS` (including `embed.FS`) as a read-only `afero.Fs` since #291, but #337 is still open because the adapter was hard to discover and the README incorrectly treated `FromIOFS` as a function (`afero.FromIOFS(assetsFS)`).

This PR closes that gap without introducing a parallel adapter:

- Add `NewFromIOFS(fs.FS) Fs` constructor consistent with other backends
- Reject write-oriented flags in `OpenFile` (aligned with `ReadOnlyFs`)
- Document bidirectional `io/fs` support, list **FromIOFS** in the backend table, and fix the embed example
- Add real `embed.FS` tests (read, readdir, mutator rejection, `CopyOnWriteFs` overlay)
- Fix the `MkdirAll` test that accidentally called `Mkdir`

### Usage

```go
//go:embed assets/*
var assetsFS embed.FS

fs := afero.NewFromIOFS(assetsFS)
data, err := afero.ReadFile(fs, "assets/config.json")

// Optional writable overlay
appFS := afero.NewCopyOnWriteFs(fs, afero.NewMemMapFs())
```

The existing `FromIOFS{FS: fsys}` composite literal remains supported.

Closes #337

## Test plan

- [x] `go test -count=1 -run 'FromIOFS|IOFS' .`
- [x] `go test -count=1 ./...`