### PR TITLE
Fix "opend" typo in gcsfs error message

### DIFF
--- a/gcsfs/file.go
+++ b/gcsfs/file.go
@@ -165,7 +165,7 @@ func (o *GcsFile) WriteAt(b []byte, off int64) (n int, err error) {
 	}
 
 	if o.openFlags&os.O_RDONLY != 0 {
-		return 0, fmt.Errorf("file is opend as read only")
+		return 0, fmt.Errorf("file is opened as read only")
 	}
 
 	_, err = o.resource.obj.Attrs(o.resource.ctx)


### PR DESCRIPTION
Fixes a typo in a user-facing error string in `gcsfs`: `"file is opend as read only"` → `"file is opened as read only"`.