### PR TITLE
docs: remove broken Discussions link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -479,7 +479,6 @@ Afero is released under the Apache 2.0 license. See [LICENSE.txt](https://github
 - [📖 Full API Documentation](https://pkg.go.dev/github.com/spf13/afero)
 - [🎯 Examples Repository](https://github.com/spf13/afero/tree/master/examples)
 - [📋 Release Notes](https://github.com/spf13/afero/releases)
-- [❓ GitHub Discussions](https://github.com/spf13/afero/discussions)
 
 ---
 


### PR DESCRIPTION
Closes #534

The Additional Resources section of README.md listed
`[❓ GitHub Discussions](https://github.com/spf13/afero/discussions)`,
but GitHub Discussions are not enabled on this repository, so the URL
returns 404. Remove the broken link and leave the other three entries
intact.

Disclosed assistance: this PR was authored with the assistance of an AI
coding assistant (Claude Code, Anthropic) operating under the maintainer's
direct supervision. The change is a single-line README edit; no
behavioural code is touched.