### PR TITLE
os: support TinyGo on js/wasm

### DIFF
--- a/const_js_tinygo.go
+++ b/const_js_tinygo.go
@@ -1,0 +1,9 @@
+//go:build tinygo && js
+
+package afero
+
+import "syscall"
+
+// TinyGo's syscall package does not define EBADFD on js/wasm; EBADF is the
+// closest available errno.
+const BADFD = syscall.EBADF

--- a/const_win_unix.go
+++ b/const_win_unix.go
@@ -10,8 +10,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//go:build !darwin && !openbsd && !freebsd && !dragonfly && !netbsd && !aix && !zos && !wasip1
-// +build !darwin,!openbsd,!freebsd,!dragonfly,!netbsd,!aix,!zos,!wasip1
+//go:build !darwin && !openbsd && !freebsd && !dragonfly && !netbsd && !aix && !zos && !wasip1 && !(tinygo && js)
 
 package afero
 

--- a/os.go
+++ b/os.go
@@ -88,11 +88,11 @@ func (OsFs) Stat(name string) (os.FileInfo, error) {
 }
 
 func (OsFs) Chmod(name string, mode os.FileMode) error {
-	return os.Chmod(name, mode)
+	return osChmod(name, mode)
 }
 
 func (OsFs) Chown(name string, uid, gid int) error {
-	return os.Chown(name, uid, gid)
+	return osChown(name, uid, gid)
 }
 
 func (OsFs) Chtimes(name string, atime time.Time, mtime time.Time) error {

--- a/os_js_tinygo.go
+++ b/os_js_tinygo.go
@@ -1,0 +1,20 @@
+//go:build tinygo && js
+
+package afero
+
+import (
+	"os"
+	"syscall"
+)
+
+// TinyGo's os package does not define Chmod, Chown or Link on the js/wasm
+// target, so afero does not compile there at all. There is no filesystem to
+// act on either, so these report ENOSYS rather than pretending to succeed.
+//
+// Only js/wasm is affected: TinyGo's linux and wasip1 targets provide all
+// three, and continue to use the standard implementations.
+
+func osChmod(name string, mode os.FileMode) error { return syscall.ENOSYS }
+func osChown(name string, uid, gid int) error     { return syscall.ENOSYS }
+
+func (OsFs) Link(oldname, newname string) error { return syscall.ENOSYS }

--- a/os_std.go
+++ b/os_std.go
@@ -1,0 +1,8 @@
+//go:build !(tinygo && js)
+
+package afero
+
+import "os"
+
+func osChmod(name string, mode os.FileMode) error { return os.Chmod(name, mode) }
+func osChown(name string, uid, gid int) error     { return os.Chown(name, uid, gid) }

--- a/os_unix.go
+++ b/os_unix.go
@@ -1,4 +1,4 @@
-//go:build !windows
+//go:build !windows && !(tinygo && js)
 
 package afero
 


### PR DESCRIPTION
TinyGo's `os` package does not define `Chmod`, `Chown` or `Link` on its js/wasm target, so afero does not compile there at all. This routes those three through small wrappers and adds js/wasm-only stubs returning `ENOSYS` — honest for a target with no filesystem to act on. `syscall.EBADFD` is likewise absent, so `BADFD` falls back to `EBADF`.

**Scoped to js/wasm, not to TinyGo generally.** That distinction is the reason for the odd-looking `!(tinygo && js)` constraints. I checked each target rather than assuming:

| TinyGo target | `os.Chmod` / `Chown` / `Link` |
|---|---|
| `linux` (native) | present — unchanged, uses the standard files |
| `wasip1` | present — unchanged |
| `wasm` (js) | **absent** — needs the stubs |

So TinyGo native and wasip1 builds keep the existing implementations; only js/wasm diverges.

Verified: `go build` and `go test` on the host pass unchanged; `tinygo build` succeeds for both the `linux` and `wasip1` targets; and `go list -tags tinygo` under `GOOS=js` selects exactly the two new files and none of the originals.

One thing I should be straight about: this is necessary but not by itself sufficient to build afero under TinyGo js/wasm today. With TinyGo 0.41.1 the build still fails afterwards inside `net/http` (`roundtrip_js.go`), which afero reaches through `HttpFs`. That is a TinyGo stdlib gap unrelated to this change, and it is being pursued separately — but I would rather say so than let the PR imply the target works end to end.