### PR TITLE
Make MemMapFs.Stat("") fail like os.Stat

### DIFF
--- a/memmap.go
+++ b/memmap.go
@@ -402,6 +402,9 @@ func (m *MemMapFs) LstatIfPossible(name string) (os.FileInfo, bool, error) {
 }
 
 func (m *MemMapFs) Stat(name string) (os.FileInfo, error) {
+	if name == "" {
+		return nil, &os.PathError{Op: "stat", Path: name, Err: os.ErrNotExist}
+	}
 	f, err := m.open(name)
 	if err != nil {
 		return nil, err

--- a/memmap_test.go
+++ b/memmap_test.go
@@ -13,6 +13,17 @@ import (
 	"time"
 )
 
+func TestMemMapFsStatEmptyPath(t *testing.T) {
+	fs := NewMemMapFs()
+	_, err := fs.Stat("")
+	if err == nil {
+		t.Fatal("Stat(\"\") should fail, matching os.Stat")
+	}
+	if !os.IsNotExist(err) {
+		t.Fatalf("Stat(\"\"): got %v, want not-exist", err)
+	}
+}
+
 func TestNormalizePath(t *testing.T) {
 	type test struct {
 		input    string


### PR DESCRIPTION
Fixes #522

`os.Stat(\"\")` returns a not-exist path error. `MemMapFs.Stat(\"\")` succeeded and returned a directory FileInfo with an empty name, so tests that inject Afero in place of the OS filesystem diverged on empty paths.

Reject the empty path with `os.ErrNotExist` wrapped in `os.PathError`, matching `os.Stat`.