### PR TITLE
Report io.EOF from UnionFile.ReadAt

### DIFF
--- a/composite_test.go
+++ b/composite_test.go
@@ -515,3 +515,28 @@ func TestUnionFileReaddirAskForTooMany(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestUnionFileReadAtReportsEOF(t *testing.T) {
+	base := NewMemMapFs()
+	layer := NewMemMapFs()
+	for _, fs := range []Fs{base, layer} {
+		if err := WriteFile(fs, "data", []byte("0123456789"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	f, err := NewCacheOnReadFs(base, layer, 0).OpenFile("data", os.O_RDWR, 0o644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	// io.ReaderAt: a short read must report why fewer bytes came back.
+	buf := make([]byte, 8)
+	if n, err := f.ReadAt(buf, 6); n != 4 || err != io.EOF {
+		t.Errorf("ReadAt short read = (%d, %v), want (4, EOF)", n, err)
+	}
+	if n, err := f.ReadAt(buf, 10); n != 0 || err != io.EOF {
+		t.Errorf("ReadAt at EOF = (%d, %v), want (0, EOF)", n, err)
+	}
+}

--- a/unionFile.go
+++ b/unionFile.go
@@ -71,7 +71,11 @@ func (f *UnionFile) ReadAt(s []byte, o int64) (int, error) {
 	if f.Layer != nil {
 		n, err := f.Layer.ReadAt(s, o)
 		if (err == nil || err == io.EOF) && f.Base != nil {
-			_, err = f.Base.Seek(o+int64(n), io.SeekStart)
+			// only overwrite err in case the seek fails: we need to
+			// report an eventual io.EOF to the caller
+			if _, seekErr := f.Base.Seek(o+int64(n), io.SeekStart); seekErr != nil {
+				err = seekErr
+			}
 		}
 		return n, err
 	}


### PR DESCRIPTION
`UnionFile.ReadAt` returns a nil error on a short read, so callers that rely on `io.EOF` to stop
never do.

`io.ReaderAt`, verbatim from `$GOROOT/src/io/io.go:210`:

> When ReadAt returns n < len(p), it returns a non-nil error explaining why more bytes were not
> returned. In this respect, ReadAt is stricter than Read.

Same calls through three implementations, 10-byte file:

```
                  ReadAt(buf[8], 6)      ReadAt(buf[8], 10)
os.File           n=4 err=EOF            n=0 err=EOF
afero mem.File    n=4 err=EOF            n=0 err=EOF
afero UnionFile   n=4 err=<nil>          n=0 err=<nil>
```

The `(0, nil)` case is what bites in practice. `io.NewSectionReader` — the natural thing to write
when the exact size is not known — cannot terminate:

```
os.File          terminated after 3 calls
afero mem.File   terminated after 3 calls
afero UnionFile  still going at 200 calls
```

Both of the other columns are afero's own code, so this is not an os-vs-mem difference.

### Cause

`unionFile.go:70`:

```go
n, err := f.Layer.ReadAt(s, o)
if (err == nil || err == io.EOF) && f.Base != nil {
    _, err = f.Base.Seek(o+int64(n), io.SeekStart)
}
return n, err
```

The assignment replaces the layer's `io.EOF` with the seek's nil. `Read`, sixteen lines above, gets
this right and carries the comment saying why:

```go
if _, seekErr := f.Base.Seek(int64(n), io.SeekCurrent); seekErr != nil {
    // only overwrite err in case the seek fails: we need to
    // report an eventual io.EOF to the caller
    err = seekErr
}
```

### Change

Five lines, mirroring `Read`. A test is added to `composite_test.go` covering the short read and the
read at EOF. Red with only `unionFile.go` reverted:

```
composite_test.go:537: ReadAt short read = (4, <nil>), want (4, EOF)
composite_test.go:540: ReadAt at EOF = (0, <nil>), want (0, EOF)
```

Green with the change; `go test ./...` passes across all packages and `gofmt -l` lists neither file.

Reachable through the public API via `NewCacheOnReadFs(base, layer, 0).OpenFile(name, os.O_RDWR,
perm)`, which returns a `*UnionFile` (`cacheOnReadFs.go:233`).

---

Disclosure: prepared with AI assistance; I verified the three-way comparison, the section-reader
behaviour and the red/green runs myself.
