### PR TITLE
Reject negative offsets in MemMapFs

### DIFF
--- a/afero_test.go
+++ b/afero_test.go
@@ -757,3 +757,29 @@ func checkSize(t *testing.T, f File, size int64) {
 		t.Errorf("Stat %q: size %d want %d", f.Name(), dir.Size(), size)
 	}
 }
+
+func TestNegativeOffsetIsAnError(t *testing.T) {
+	defer removeAllTestFiles(t)
+	for _, fs := range Fss {
+		f := tmpFile(fs)
+		f.WriteString("hello")
+		f.Close()
+
+		g, err := fs.Open(f.Name())
+		if err != nil {
+			t.Fatalf("%T: %v", fs, err)
+		}
+
+		// Seeking before the start of the file is an error, as it is for os.File.
+		if _, err := g.Seek(-1, io.SeekStart); err == nil {
+			t.Errorf("%T: Seek(-1, SeekStart) returned no error", fs)
+		}
+		if _, err := g.Seek(-8, io.SeekEnd); err == nil {
+			t.Errorf("%T: Seek(-8, SeekEnd) on a 5-byte file returned no error", fs)
+		}
+		if _, err := g.ReadAt(make([]byte, 4), -1); err == nil {
+			t.Errorf("%T: ReadAt(-1) returned no error", fs)
+		}
+		g.Close()
+	}
+}

--- a/mem/file.go
+++ b/mem/file.go
@@ -219,6 +219,9 @@ func (f *File) ReadAt(b []byte, off int64) (n int, err error) {
 	if f.closed {
 		return 0, ErrFileClosed
 	}
+	if off < 0 {
+		return 0, ErrOutOfRange
+	}
 	if len(b) > 0 && int(off) == len(f.fileData.data) {
 		return 0, io.EOF
 	}
@@ -276,15 +279,23 @@ func (f *File) Seek(offset int64, whence int) (int64, error) {
 	if f.closed {
 		return 0, ErrFileClosed
 	}
+	var at int64
 	switch whence {
 	case io.SeekStart:
-		atomic.StoreInt64(&f.at, offset)
+		at = offset
 	case io.SeekCurrent:
-		atomic.AddInt64(&f.at, offset)
+		at = atomic.LoadInt64(&f.at) + offset
 	case io.SeekEnd:
-		atomic.StoreInt64(&f.at, int64(len(f.fileData.data))+offset)
+		at = int64(len(f.fileData.data)) + offset
+	default:
+		return 0, ErrOutOfRange
 	}
-	return f.at, nil
+	if at < 0 {
+		// a negative offset is an error, as it is for os.File
+		return 0, ErrOutOfRange
+	}
+	atomic.StoreInt64(&f.at, at)
+	return at, nil
 }
 
 func (f *File) WriteAt(b []byte, off int64) (n int, err error) {
@@ -297,6 +308,9 @@ func (f *File) WriteAt(b []byte, off int64) (n int, err error) {
 			Path: f.fileData.name,
 			Err:  errors.New("file handle is read only"),
 		}
+	}
+	if off < 0 {
+		return 0, ErrOutOfRange
 	}
 	n = len(b)
 	f.fileData.Lock()


### PR DESCRIPTION
`MemMapFs` accepts a negative seek offset and then panics on the next read, where `OsFs` returns an
error.

Reading the last N bytes of a file shorter than N is the usual way to hit it:

```go
f.Seek(-8, io.SeekEnd)   // 5-byte file
f.Read(buf)              // panic: slice bounds out of range [-3:]
```

Same three calls through both backends of the shared suite:

```
           Seek(-1, SeekStart)   Seek(-8, SeekEnd) then Read      ReadAt(buf, -1)
OsFs       error                 error from Seek, read unaffected error
MemMapFs   n=-1, no error        panic: slice bounds out of range [-3:]   panic: [-1:]
```

`OsFs` is the correct half. `io.Seeker` says "Seeking to an offset before the start of the file is
an error", and `os.File` returns `EINVAL` for the seek and `negative offset` for `ReadAt`.

### Cause

`mem/file.go:275` stores whatever the arithmetic produces:

```go
case io.SeekEnd:
    atomic.StoreInt64(&f.at, int64(len(f.fileData.data))+offset)
```

and `mem/file.go:233` then slices with it:

```go
copy(b, f.fileData.data[off:off+int64(n)])
```

`ReadAt` and `WriteAt` have the same gap for a caller-supplied negative `off`.

### Change

A negative-offset guard in `Seek`, `ReadAt` and `WriteAt`, returning the `ErrOutOfRange` sentinel
this file already uses for `Truncate(-1)` (`mem/file.go:261`). `Seek` now computes into a local and
validates before storing, which also makes an unknown `whence` an error rather than a silent no-op —
`os.File` rejects that too.

### Test

Added to `afero_test.go`, which runs over `Fss = []Fs{&MemMapFs{}, &OsFs{}}`, so `OsFs` defines the
expected behaviour rather than me asserting it. With only `mem/file.go` reverted, `OsFs` passes and
`MemMapFs` fails on the seeks and then panics on the `ReadAt`:

```
afero_test.go:775: *afero.MemMapFs: Seek(-1, SeekStart) returned no error
afero_test.go:778: *afero.MemMapFs: Seek(-8, SeekEnd) on a 5-byte file returned no error
panic: runtime error: slice bounds out of range [-1:]
    github.com/spf13/afero/mem.(*File).ReadAt
```

With the change both backends pass. `go test ./...` and `go test -race ./ ./mem` are green, and
`gofmt -l` lists neither file.

---

Disclosure: prepared with AI assistance; I verified the backend comparison and the red/green runs
myself.
