### PR TITLE
Honor access mode in MemMapFs.OpenFile permission checks

### DIFF
--- a/memmap.go
+++ b/memmap.go
@@ -225,11 +225,14 @@ func (m *MemMapFs) Open(name string) (File, error) {
 	return nil, err
 }
 
-func (m *MemMapFs) openWrite(name string) (File, error) {
+func (m *MemMapFs) openFile(name string, flag int) (File, error) {
 	f, err := m.open(name)
 	if f != nil {
-		// Check write permission (owner bits).
-		if mem.GetFileInfo(f).Mode().Perm()&0o222 == 0 {
+		mode := mem.GetFileInfo(f).Mode().Perm()
+		if flag&os.O_WRONLY == 0 && mode&0o444 == 0 {
+			return nil, &os.PathError{Op: "open", Path: name, Err: os.ErrPermission}
+		}
+		if flag&(os.O_WRONLY|os.O_RDWR) != 0 && mode&0o222 == 0 {
 			return nil, &os.PathError{Op: "open", Path: name, Err: os.ErrPermission}
 		}
 		return mem.NewFileHandle(f), err
@@ -262,7 +265,7 @@ func (m *MemMapFs) lockfreeOpen(name string) (*mem.FileData, error) {
 func (m *MemMapFs) OpenFile(name string, flag int, perm os.FileMode) (File, error) {
 	perm &= chmodBits
 	chmod := false
-	file, err := m.openWrite(name)
+	file, err := m.openFile(name, flag)
 	if err == nil && (flag&os.O_EXCL > 0) {
 		return nil, &os.PathError{Op: "open", Path: name, Err: ErrFileExists}
 	}
@@ -273,7 +276,7 @@ func (m *MemMapFs) OpenFile(name string, flag int, perm os.FileMode) (File, erro
 	if err != nil {
 		return nil, err
 	}
-	if flag == os.O_RDONLY {
+	if flag&(os.O_WRONLY|os.O_RDWR) == 0 {
 		file = mem.NewReadOnlyFileHandle(file.(*mem.File).Data())
 	}
 	if flag&os.O_APPEND > 0 {

--- a/memmap_test.go
+++ b/memmap_test.go
@@ -1125,3 +1125,57 @@ func TestMemMapFsPermissionChecks(t *testing.T) {
 		t.Fatalf("expected permission error, got: %v", err)
 	}
 }
+
+func TestMemMapFsOpenFileAccessMode(t *testing.T) {
+	for _, tt := range []struct {
+		mode                   os.FileMode
+		read, write, readWrite bool
+	}{
+		{0o000, false, false, false},
+		{0o444, true, false, false},
+		{0o222, false, true, false},
+		{0o666, true, true, true},
+	} {
+		for _, access := range []struct {
+			name    string
+			flag    int
+			allowed bool
+		}{
+			{"read", os.O_RDONLY, tt.read},
+			{"write", os.O_WRONLY, tt.write},
+			{"read-write", os.O_RDWR, tt.readWrite},
+		} {
+			t.Run(fmt.Sprintf("%03o/%s", tt.mode, access.name), func(t *testing.T) {
+				fs := NewMemMapFs()
+				if err := WriteFile(fs, "file", []byte("content"), tt.mode); err != nil {
+					t.Fatal(err)
+				}
+				f, err := fs.OpenFile("file", access.flag, 0)
+				if f != nil {
+					defer f.Close()
+				}
+				if access.allowed {
+					if err != nil {
+						t.Fatalf("OpenFile: %v", err)
+					}
+				} else if !os.IsPermission(err) {
+					t.Fatalf("expected permission error, got %v", err)
+				}
+			})
+		}
+	}
+}
+
+func TestMemMapFsOpenFileReadOnlyWithCreate(t *testing.T) {
+	fs := NewMemMapFs()
+	for i := 0; i < 2; i++ {
+		f, err := fs.OpenFile("file", os.O_RDONLY|os.O_CREATE, 0o444)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := f.Write([]byte("unexpected")); err == nil {
+			t.Error("read-only handle allowed a write")
+		}
+		f.Close()
+	}
+}


### PR DESCRIPTION
`MemMapFs.OpenFile` always checks write permissions, including for `O_RDONLY`. As a result, a mode-0444 file can be opened with `Open` but not `OpenFile`, while a mode-0222 file incorrectly permits `O_RDONLY` and `O_RDWR`.

Check the permissions required by the access mode, following up on the permission checks applied from #573. Also keep handles read-only when `O_RDONLY` is combined with flags such as `O_CREATE`.

The regression tests cover read, write, and read/write access for modes 0000, 0444, 0222, and 0666, plus read-only creation and reopening. The affected cases fail on master. `go test -race ./...` and `go vet ./...` pass in the root module; changed files are gofmt-formatted.

Implemented and validated with OpenAI Codex.
