### PR TITLE
Check source existence before a no-op MemMapFs rename

### DIFF
--- a/memmap.go
+++ b/memmap.go
@@ -339,13 +339,13 @@ func (m *MemMapFs) Rename(oldname, newname string) error {
 	oldname = normalizePath(oldname)
 	newname = normalizePath(newname)
 
-	if oldname == newname {
-		return nil
-	}
-
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	if _, ok := m.getData()[oldname]; ok {
+		if oldname == newname {
+			return nil
+		}
+
 		m.mu.RUnlock()
 		m.mu.Lock()
 		err := m.unRegisterWithParent(oldname)

--- a/memmap_test.go
+++ b/memmap_test.go
@@ -1125,3 +1125,30 @@ func TestMemMapFsPermissionChecks(t *testing.T) {
 		t.Fatalf("expected permission error, got: %v", err)
 	}
 }
+
+func TestMemMapFsRenameMissingSourceToItself(t *testing.T) {
+	for _, newname := range []string{"missing", "./missing"} {
+		t.Run(newname, func(t *testing.T) {
+			fs := NewMemMapFs()
+			err := fs.Rename("missing", newname)
+			if !os.IsNotExist(err) {
+				t.Fatalf("expected a missing source error, got %v", err)
+			}
+			checkPathError(t, err, "Rename")
+		})
+	}
+}
+
+func TestMemMapFsRenameExistingSourceToItself(t *testing.T) {
+	fs := NewMemMapFs()
+	if err := WriteFile(fs, "file", []byte("content"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := fs.Rename("file", "./file"); err != nil {
+		t.Fatal(err)
+	}
+	content, err := ReadFile(fs, "file")
+	if err != nil || string(content) != "content" {
+		t.Fatalf("file changed after rename: %q, %v", content, err)
+	}
+}


### PR DESCRIPTION
`MemMapFs.Rename("missing", "missing")` currently succeeds even though the source does not exist. The early return also applies to equivalent normalized paths such as `"missing"` and `"./missing"`, hiding missing-source errors from code tested against MemMapFs.

Check that the source exists before treating the rename as a no-op. Existing files renamed to themselves still succeed and retain their contents.

Added regression tests for identical and equivalent missing paths, plus the existing-file case. The missing-source tests fail on master. `go test -race ./...` and `go vet ./...` pass in the root module; changed files are gofmt-formatted.

Implemented and validated with OpenAI Codex.
